### PR TITLE
Improve usability of ConsumeMessagesCommand

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,7 @@ services:
         command: bin/restartOnChange bin/console identity:follow-event-store pointer --select-all-subscribers
     php-consume-messages:
         <<: *php-container
-        command: bin/restartOnChange bin/console gaming:consume-messages --select-all-consumers
+        command: bin/restartOnChange bin/console gaming:consume-messages --select-all-consumers -v
     php-web-interface-publish-running-games-count-to-nchan:
         <<: *php-container
         command: bin/restartOnChange bin/console web-interface:publish-running-games-count-to-nchan

--- a/src/Common/Port/Adapter/Symfony/ConsumeMessagesCommand.php
+++ b/src/Common/Port/Adapter/Symfony/ConsumeMessagesCommand.php
@@ -60,7 +60,7 @@ final class ConsumeMessagesCommand extends Command
         if (count($unknownConsumerNames) !== 0) {
             $output->writeln(
                 sprintf(
-                    'The following subscribers are unknown:%s* %s',
+                    'The following consumers are unknown:%s* %s',
                     PHP_EOL,
                     implode(PHP_EOL . '* ', $unknownConsumerNames)
                 )

--- a/src/Common/Port/Adapter/Symfony/ConsumeMessagesCommand.php
+++ b/src/Common/Port/Adapter/Symfony/ConsumeMessagesCommand.php
@@ -44,32 +44,85 @@ final class ConsumeMessagesCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $availableConsumers = iterator_to_array($this->consumers);
-
-        $selectedConsumerNames = $input->getOption('consumer');
-        if ($input->getOption('select-all-consumers')) {
-            $selectedConsumerNames = array_keys($availableConsumers);
-        }
-
-        $consumers = [];
-        foreach ($selectedConsumerNames as $selectedConsumerName) {
-            if (!array_key_exists($selectedConsumerName, $availableConsumers)) {
-                $output->writeln('Consumer "' . $selectedConsumerName . '" not known.');
-                return Command::FAILURE;
-            }
-            $consumers[] = new SymfonyConsoleConsumer(
-                $availableConsumers[$selectedConsumerName],
-                $output
+        $selectedConsumerNames = $this->selectedConsumerNames($input);
+        if (count($selectedConsumerNames) === 0) {
+            $output->writeln(
+                sprintf(
+                    'Please select one of the following consumers:%s* %s',
+                    PHP_EOL,
+                    implode(PHP_EOL . '* ', $this->availableConsumerNames())
+                )
             );
-        }
-
-        if (count($consumers) === 0) {
-            $output->writeln('No consumer selected.');
             return Command::FAILURE;
         }
 
-        $this->messageBroker->consume($consumers);
+        $unknownConsumerNames = $this->unknownConsumerNames($input);
+        if (count($unknownConsumerNames) !== 0) {
+            $output->writeln(
+                sprintf(
+                    'The following subscribers are unknown:%s* %s',
+                    PHP_EOL,
+                    implode(PHP_EOL . '* ', $unknownConsumerNames)
+                )
+            );
+            return Command::FAILURE;
+        }
+
+        $this->messageBroker->consume(
+            $this->createConsumers($input, $output)
+        );
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function selectedConsumerNames(InputInterface $input): array
+    {
+        return $input->getOption('select-all-consumers') ?
+            $this->availableConsumerNames() :
+            $input->getOption('consumer');
+    }
+
+    /**
+     * @return string[]
+     */
+    private function availableConsumerNames(): array
+    {
+        return array_keys(iterator_to_array($this->consumers));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function unknownConsumerNames(InputInterface $input): array
+    {
+        return array_keys(
+            array_diff_key(
+                array_flip($this->selectedConsumerNames($input)),
+                iterator_to_array($this->consumers)
+            )
+        );
+    }
+
+    /**
+     * @return iterable<Consumer>
+     */
+    private function createConsumers(InputInterface $input, OutputInterface $output): iterable
+    {
+        $consumers = array_intersect_key(
+            iterator_to_array($this->consumers),
+            array_flip($this->selectedConsumerNames($input))
+        );
+
+        if ($output->isVerbose()) {
+            $consumers = array_map(
+                static fn(Consumer $consumer) => new SymfonyConsoleConsumer($consumer, $output),
+                $consumers
+            );
+        }
+
+        return $consumers;
     }
 }


### PR DESCRIPTION
* The `-v` command option outputs the received messages to stdout.
* If a non-existing consumer is selected, the command exits.
* If no consumer is selected, all available consumers are shown.