### PR TITLE
Provide scheduler library

### DIFF
--- a/src/Common/Scheduler/CollectJobsScheduler.php
+++ b/src/Common/Scheduler/CollectJobsScheduler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+final class CollectJobsScheduler implements Scheduler
+{
+    public readonly Jobs $jobs;
+
+    public function __construct()
+    {
+        $this->jobs = new Jobs();
+    }
+
+    public function schedule(int $invokeAt, Handler $handler): void
+    {
+        $this->jobs->add($invokeAt, $handler);
+    }
+}

--- a/src/Common/Scheduler/Handler.php
+++ b/src/Common/Scheduler/Handler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+interface Handler
+{
+    public function handle(Scheduler $scheduler): void;
+}

--- a/src/Common/Scheduler/Job.php
+++ b/src/Common/Scheduler/Job.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+final class Job
+{
+    public function __construct(
+        public readonly int $invokeAt,
+        public readonly Handler $handler
+    ) {
+    }
+}

--- a/src/Common/Scheduler/Jobs.php
+++ b/src/Common/Scheduler/Jobs.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+use Closure;
+
+final class Jobs
+{
+    /**
+     * @var Job[]
+     */
+    private array $jobs;
+
+    public function __construct()
+    {
+        $this->jobs = [];
+    }
+
+    public function add(int $invokeAt, Handler $handler): void
+    {
+        $this->jobs[] = new Job($invokeAt, $handler);
+    }
+
+    /**
+     * @param Closure(Job): bool $closure
+     */
+    public function remove(Closure $closure): void
+    {
+        $this->jobs = array_filter(
+            $this->jobs,
+            static fn(Job $job): bool => !$closure($job)
+        );
+    }
+
+    /**
+     * @return array<Job>
+     */
+    public function filter(Closure $closure): array
+    {
+        return array_filter($this->jobs, $closure);
+    }
+
+    public function merge(Jobs $jobs): void
+    {
+        $this->jobs = array_merge(
+            $this->jobs,
+            $jobs->jobs
+        );
+    }
+
+    public function next(): Job|false
+    {
+        usort(
+            $this->jobs,
+            static fn(Job $left, Job $right): int => $left->invokeAt <=> $right->invokeAt
+        );
+
+        return reset($this->jobs);
+    }
+}

--- a/src/Common/Scheduler/NullHandler.php
+++ b/src/Common/Scheduler/NullHandler.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+final class NullHandler implements Handler
+{
+    public function handle(Scheduler $scheduler): void
+    {
+    }
+}

--- a/src/Common/Scheduler/PcntlScheduler.php
+++ b/src/Common/Scheduler/PcntlScheduler.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+final class PcntlScheduler implements Scheduler
+{
+    private readonly Jobs $jobs;
+
+    private bool $isInitialized;
+
+    public function __construct()
+    {
+        $this->jobs = new Jobs();
+        $this->isInitialized = false;
+    }
+
+    public function schedule(int $invokeAt, Handler $handler): void
+    {
+        $this->initialize();
+
+        $this->jobs->add($invokeAt, $handler);
+
+        $this->setAlarmClock();
+    }
+
+    private function initialize(): void
+    {
+        if ($this->isInitialized) {
+            return;
+        }
+
+        pcntl_async_signals(true);
+        pcntl_signal(SIGALRM, $this->onAlarm(...));
+
+        $this->isInitialized = true;
+    }
+
+    private function onAlarm(): void
+    {
+        $collectJobsScheduler = new CollectJobsScheduler();
+
+        $selectedJobs = $this->jobs->filter(
+            static fn(Job $job) => $job->invokeAt <= time()
+        );
+
+        foreach ($selectedJobs as $job) {
+            $job->handler->handle($collectJobsScheduler);
+        }
+
+        $this->jobs->remove(
+            static fn(Job $job): bool => in_array($job, $selectedJobs)
+        );
+
+        $this->jobs->merge($collectJobsScheduler->jobs);
+
+        $this->setAlarmClock();
+    }
+
+    private function setAlarmClock(): void
+    {
+        $nextJob = $this->jobs->next();
+        if (!$nextJob) {
+            return;
+        }
+
+        pcntl_alarm(max(1, $nextJob->invokeAt - time()));
+    }
+}

--- a/src/Common/Scheduler/Scheduler.php
+++ b/src/Common/Scheduler/Scheduler.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Scheduler;
+
+interface Scheduler
+{
+    public function schedule(int $invokeAt, Handler $handler): void;
+}

--- a/tests/unit/Common/Scheduler/PcntlSchedulerTest.php
+++ b/tests/unit/Common/Scheduler/PcntlSchedulerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Tests\Unit\Common\Scheduler;
+
+use Gaming\Common\Scheduler\Handler;
+use Gaming\Common\Scheduler\NullHandler;
+use Gaming\Common\Scheduler\PcntlScheduler;
+use Gaming\Common\Scheduler\Scheduler;
+use PHPUnit\Framework\TestCase;
+
+final class PcntlSchedulerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldSchedule(): void
+    {
+        $expectedCount = 2;
+
+        $testHandler = new class ($expectedCount) implements Handler {
+            public function __construct(
+                public readonly int $expectedCount,
+                public int $count = 0,
+            ) {
+            }
+
+            public function handle(Scheduler $scheduler): void
+            {
+                if (++$this->count === $this->expectedCount) {
+                    return;
+                }
+
+                $scheduler->schedule(time(), $this);
+            }
+        };
+
+        $scheduler = new PcntlScheduler();
+
+        $scheduler->schedule(
+            time(),
+            $testHandler
+        );
+
+        $scheduler->schedule(
+            time(),
+            new NullHandler()
+        );
+
+        // This test needs to sleep, otherwise the SIGALRM implementation cannot be tested.
+        $seconds = 3;
+        while ($seconds = sleep($seconds));
+
+        self::assertSame($expectedCount, $testHandler->count);
+    }
+}


### PR DESCRIPTION
The scheduler can be used to interrupt the application at a certain time to trigger certain handlers. It's an abstraction around `pcntl_alarm` with the advantage that multiple handlers can be registered. For example, heartbeats can be sent to applications such as RabbitMQ or MySQL to maintain connections in a long-running process without having to switch the execution model (e.g. fibers) of those processes.

It's not the best library name, but the name serves its purpose for now.