### PR TITLE
Add migration extension for Normalizer

### DIFF
--- a/src/Common/Normalizer/MigratingNormalizer.php
+++ b/src/Common/Normalizer/MigratingNormalizer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Normalizer;
+
+final class MigratingNormalizer implements Normalizer
+{
+    /**
+     * @var array<string, Migrations>
+     */
+    private readonly array $typeToMigrationsMap;
+
+    /**
+     * @param iterable<string, Migrations> $typeToMigrationsMap
+     */
+    public function __construct(
+        private readonly Normalizer $normalizer,
+        iterable $typeToMigrationsMap
+    ) {
+        $this->typeToMigrationsMap = [...$typeToMigrationsMap];
+    }
+
+    public function normalize(mixed $value, string $typeName): mixed
+    {
+        $typeMigrations = $this->typeToMigrationsMap[$typeName] ?? null;
+        $normalized = $this->normalizer->normalize($value, $typeName);
+        if ($typeMigrations === null || !is_array($normalized)) {
+            return $normalized;
+        }
+
+        $normalized[$typeMigrations->versionKey()] = $typeMigrations->latestVersion();
+
+        return $normalized;
+    }
+
+    public function denormalize(mixed $value, string $typeName): mixed
+    {
+        $migrations = $this->typeToMigrationsMap[$typeName] ?? null;
+        if ($migrations === null || !is_array($value)) {
+            return $this->normalizer->denormalize($value, $typeName);
+        }
+
+        $currentSchemaVersion = 0;
+        if (array_key_exists($migrations->versionKey(), $value)) {
+            $currentSchemaVersion = (int)$value[$migrations->versionKey()];
+            unset($value[$migrations->versionKey()]);
+        }
+
+        return $this->normalizer->denormalize(
+            $migrations->migrate($currentSchemaVersion, $value),
+            $typeName
+        );
+    }
+}

--- a/src/Common/Normalizer/Migration.php
+++ b/src/Common/Normalizer/Migration.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Normalizer;
+
+interface Migration
+{
+    /**
+     * @param array<string, mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    public function migrate(array $value): array;
+}

--- a/src/Common/Normalizer/Migrations.php
+++ b/src/Common/Normalizer/Migrations.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Normalizer;
+
+final class Migrations
+{
+    /**
+     * @var Migration[]
+     */
+    private readonly array $migrations;
+
+    /**
+     * @param iterable<Migration> $migrations
+     */
+    public function __construct(
+        private readonly string $versionKey,
+        iterable $migrations
+    ) {
+        $this->migrations = [...$migrations];
+    }
+
+    /**
+     * @param array<string, mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    public function migrate(int $currentSchemaVersion, array $value): array
+    {
+        return array_reduce(
+            array_slice($this->migrations, $currentSchemaVersion),
+            static fn(array $carry, Migration $migration): array => $migration->migrate($carry),
+            $value
+        );
+    }
+
+    public function latestVersion(): int
+    {
+        return count($this->migrations);
+    }
+
+    public function versionKey(): string
+    {
+        return $this->versionKey;
+    }
+}

--- a/src/Common/Normalizer/Test/TestMigration.php
+++ b/src/Common/Normalizer/Test/TestMigration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Normalizer\Test;
+
+use Gaming\Common\Normalizer\Migration;
+
+final class TestMigration implements Migration
+{
+    public function __construct(
+        private readonly string $key
+    ) {
+    }
+
+    public function migrate(array $value): array
+    {
+        $value[$this->key] = true;
+
+        return $value;
+    }
+}

--- a/src/Common/Normalizer/Test/TestMigration.php
+++ b/src/Common/Normalizer/Test/TestMigration.php
@@ -6,6 +6,9 @@ namespace Gaming\Common\Normalizer\Test;
 
 use Gaming\Common\Normalizer\Migration;
 
+/**
+ * This class can be used for testing purposes.
+ */
 final class TestMigration implements Migration
 {
     public function __construct(

--- a/src/Common/Normalizer/Test/TestNormalizer.php
+++ b/src/Common/Normalizer/Test/TestNormalizer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Normalizer\Test;
+
+use Gaming\Common\Normalizer\Normalizer;
+
+final class TestNormalizer implements Normalizer
+{
+    public function normalize(mixed $value, string $typeName): mixed
+    {
+        return $value;
+    }
+
+    public function denormalize(mixed $value, string $typeName): mixed
+    {
+        return $value;
+    }
+}

--- a/src/Common/Normalizer/Test/TestNormalizer.php
+++ b/src/Common/Normalizer/Test/TestNormalizer.php
@@ -6,6 +6,9 @@ namespace Gaming\Common\Normalizer\Test;
 
 use Gaming\Common\Normalizer\Normalizer;
 
+/**
+ * This class can be used for testing purposes.
+ */
 final class TestNormalizer implements Normalizer
 {
     public function normalize(mixed $value, string $typeName): mixed

--- a/tests/unit/Common/Normalizer/MigratingNormalizerTest.php
+++ b/tests/unit/Common/Normalizer/MigratingNormalizerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Tests\Unit\Common\Normalizer;
+
+use Gaming\Common\Normalizer\MigratingNormalizer;
+use Gaming\Common\Normalizer\Migration;
+use Gaming\Common\Normalizer\Migrations;
+use Gaming\Common\Normalizer\Normalizer;
+use Gaming\Common\Normalizer\Test\TestMigration;
+use Gaming\Common\Normalizer\Test\TestNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class MigratingNormalizerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function itShouldAddTheLatestVersionKeyAfterNormalization(): void
+    {
+        $migratingNormalizer = $this->createMigratingNormalizer(
+            'array',
+            [new TestMigration('m1'), new TestMigration('m2')]
+        );
+
+        self::assertEquals(
+            ['language' => 'php', 'schemaVersion' => 2],
+            $migratingNormalizer->normalize(['language' => 'php'], 'array')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldApplyAllMigrationsBeforeDenormalizeBeginningFromTheLatest(): void
+    {
+        $migratingNormalizer = $this->createMigratingNormalizer(
+            'array',
+            [new TestMigration('m1'), new TestMigration('m2'), new TestMigration('m3')]
+        );
+
+        self::assertEquals(
+            ['language' => 'php', 'm1' => true, 'm2' => true, 'm3' => true],
+            $migratingNormalizer->denormalize(['language' => 'php'], 'array')
+        );
+
+        self::assertEquals(
+            ['language' => 'php', 'm1' => true, 'm2' => true, 'm3' => true],
+            $migratingNormalizer->denormalize(['language' => 'php', 'schemaVersion' => 0], 'array')
+        );
+
+        self::assertEquals(
+            ['language' => 'php', 'm2' => true, 'm3' => true],
+            $migratingNormalizer->denormalize(['language' => 'php', 'schemaVersion' => 1], 'array')
+        );
+
+        self::assertEquals(
+            ['language' => 'php', 'm3' => true],
+            $migratingNormalizer->denormalize(['language' => 'php', 'schemaVersion' => 2], 'array')
+        );
+
+        self::assertEquals(
+            ['language' => 'php'],
+            $migratingNormalizer->denormalize(['language' => 'php', 'schemaVersion' => 3], 'array')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldIgnoreAllTypesWithoutMigrations(): void
+    {
+        $migratingNormalizer = $this->createMigratingNormalizer(
+            'int',
+            [new TestMigration('m1')]
+        );
+
+        self::assertEquals(
+            ['language' => 'php'],
+            $migratingNormalizer->normalize(['language' => 'php'], 'array')
+        );
+
+        self::assertEquals(
+            ['language' => 'php'],
+            $migratingNormalizer->denormalize(['language' => 'php'], 'array')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldIgnoreAnyTypeButArrays(): void
+    {
+        $migration = $this->createMock(Migration::class);
+        $migratingNormalizer = $this->createMigratingNormalizer('int', [$migration]);
+
+        $migration->expects($this->never())->method('migrate');
+
+        self::assertEquals(3, $migratingNormalizer->normalize(3, 'int'));
+
+        $migratingNormalizer->denormalize(3, 'int');
+    }
+
+    /**
+     * @param Migration[] $migrations
+     */
+    private function createMigratingNormalizer(string $typeName, array $migrations): Normalizer
+    {
+        return new MigratingNormalizer(
+            new TestNormalizer(),
+            [$typeName => new Migrations('schemaVersion', $migrations)]
+        );
+    }
+}


### PR DESCRIPTION
Any Normalizer can be decorated with the MigratingNormalizer to migrate the schema of the types to be denormalized before they are given to the decorated Normalizer. The MigratingNormalizer ignores all types but arrays, because information like the current version schema is stored.