### PR TITLE
Reduce size of game query model

### DIFF
--- a/config/connect-four/services/game.yml
+++ b/config/connect-four/services/game.yml
@@ -33,6 +33,7 @@ services:
         arguments:
             - '@connect-four.predis'
             - 'game.'
+            - '@connect-four.normalizer'
             - '@connect-four.game-repository'
 
     connect-four.games-by-player-store:


### PR DESCRIPTION
Use json instead of the PHP serialization format.

Tested with 25k req/s for a duration of 10 minutes. The subscriber could handle the load. No `gzcompress` or smarter ways to store the game needed for now.