### PR TITLE
Initiate chats exactly once

### DIFF
--- a/.env
+++ b/.env
@@ -12,6 +12,7 @@ APP_RABBIT_MQ_DSN=amqp://guest:guest@rabbit-mq:5672?receive_method=basic_consume
 ############################
 APP_CHAT_DOCTRINE_DBAL_URL=mysqli://root:password@localhost/chat?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock
 APP_CHAT_RUN_MIGRATIONS=1
+APP_CHAT_PREDIS_CLIENT_URL=redis://redis:6379?persistent=1
 
 ############################
 #   Connect Four Context   #

--- a/config/chat/services/chat.yml
+++ b/config/chat/services/chat.yml
@@ -15,6 +15,12 @@ services:
             - 'chat'
             - 'message'
 
+    chat.idempotent-chat-id-storage:
+        class: Gaming\Common\IdempotentStorage\PredisIdempotentStorage
+        arguments:
+            - '@chat.predis'
+            - 86400
+
     chat.chat-service:
         class: Gaming\Chat\Application\ChatService
         public: false
@@ -22,3 +28,4 @@ services:
             - '@chat.chat-gateway'
             - '@chat.event-store'
             - '@clock'
+            - '@chat.idempotent-chat-id-storage'

--- a/config/chat/services/persistence.yml
+++ b/config/chat/services/persistence.yml
@@ -1,5 +1,12 @@
 services:
 
+    chat.predis:
+        class: Predis\Client
+        public: false
+        arguments:
+            - '%env(APP_CHAT_PREDIS_CLIENT_URL)%'
+            - { prefix: 'chat.' }
+
     chat.doctrine-dbal:
         alias: 'doctrine.dbal.chat_connection'
 

--- a/deploy/single-server/docker-compose.yml
+++ b/deploy/single-server/docker-compose.yml
@@ -12,6 +12,7 @@ x-php-container:
         APP_RABBIT_MQ_DSN: "amqp://guest:guest@rabbit-mq:5672?receive_method=basic_consume&qos_prefetch_count=10&heartbeat=60"
         APP_CHAT_DOCTRINE_DBAL_URL: "mysqli://root:password@localhost/chat?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock"
         APP_CHAT_RUN_MIGRATIONS: "1"
+        APP_CHAT_PREDIS_CLIENT_URL: "redis://redis:6379?persistent=1"
         APP_CONNECT_FOUR_DOCTRINE_DBAL_URL: "mysqli://root:password@localhost?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock"
         APP_CONNECT_FOUR_DOCTRINE_DBAL_DATABASE: "connect-four"
         APP_CONNECT_FOUR_DOCTRINE_DBAL_SHARDS: "connect-four"

--- a/src/Chat/Application/ChatGateway.php
+++ b/src/Chat/Application/ChatGateway.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace Gaming\Chat\Application;
 
 use DateTimeImmutable;
+use Gaming\Chat\Application\Exception\ChatAlreadyExistsException;
 use Gaming\Chat\Application\Exception\ChatNotFoundException;
 
 interface ChatGateway
 {
+    public function nextIdentity(): ChatId;
+
     /**
      * @param string[] $authors
+     *
+     * @throws ChatAlreadyExistsException
      */
-    public function create(array $authors): ChatId;
+    public function create(ChatId $chatId, array $authors): void;
 
     public function createMessage(
         ChatId $chatId,

--- a/src/Chat/Application/Command/InitiateChatCommand.php
+++ b/src/Chat/Application/Command/InitiateChatCommand.php
@@ -7,16 +7,17 @@ namespace Gaming\Chat\Application\Command;
 final class InitiateChatCommand
 {
     /**
-     * @var string[]
-     */
-    private array $authors;
-
-    /**
      * @param string[] $authors
      */
-    public function __construct(array $authors)
+    public function __construct(
+        private readonly string $idempotencyKey,
+        private readonly array $authors
+    ) {
+    }
+
+    public function idempotencyKey(): string
     {
-        $this->authors = $authors;
+        return $this->idempotencyKey;
     }
 
     /**

--- a/src/Chat/Application/Exception/ChatAlreadyExistsException.php
+++ b/src/Chat/Application/Exception/ChatAlreadyExistsException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Chat\Application\Exception;
+
+final class ChatAlreadyExistsException extends ChatException
+{
+}

--- a/src/Chat/Infrastructure/Messaging/CommandConsumer.php
+++ b/src/Chat/Infrastructure/Messaging/CommandConsumer.php
@@ -28,6 +28,7 @@ final class CommandConsumer implements Consumer
 
         $chatId = $this->commandBus->handle(
             new InitiateChatCommand(
+                $payload['idempotencyKey'],
                 $payload['authors']
             )
         );

--- a/src/Common/IdempotentStorage/IdempotentStorage.php
+++ b/src/Common/IdempotentStorage/IdempotentStorage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\IdempotentStorage;
+
+/**
+ * @template T
+ */
+interface IdempotentStorage
+{
+    /**
+     * The first call with a specific idempotency key will return the value.
+     * Any subsequent calls with the same idempotency key will return the value of the first call.
+     * Always rely on the return value of this method, never on the passed value.
+     *
+     * Implementations may decide to expire the idempotency key after a certain amount of time.
+     * Implementations must be concurrent safe.
+     *
+     * @param T $value
+     *
+     * @return T
+     */
+    public function add(string $idempotencyKey, mixed $value): mixed;
+}

--- a/src/Common/IdempotentStorage/InMemoryIdempotentStorage.php
+++ b/src/Common/IdempotentStorage/InMemoryIdempotentStorage.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\IdempotentStorage;
+
+/**
+ * @template T
+ * @implements IdempotentStorage<T>
+ */
+final class InMemoryIdempotentStorage implements IdempotentStorage
+{
+    /**
+     * @var T[]
+     */
+    private array $storage = [];
+
+    public function add(string $idempotencyKey, mixed $value): mixed
+    {
+        return $this->storage[$idempotencyKey] ??= $value;
+    }
+}

--- a/src/Common/IdempotentStorage/PredisIdempotentStorage.php
+++ b/src/Common/IdempotentStorage/PredisIdempotentStorage.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\IdempotentStorage;
+
+use Predis\ClientInterface;
+
+/**
+ * @template T
+ * @implements IdempotentStorage<T>
+ */
+final class PredisIdempotentStorage implements IdempotentStorage
+{
+    public function __construct(
+        private readonly ClientInterface $predis,
+        private readonly int $expireTimeInSeconds
+    ) {
+    }
+
+    public function add(string $idempotencyKey, mixed $value): mixed
+    {
+        $result = $this->predis->setnx($idempotencyKey, serialize($value));
+        $this->predis->expire($idempotencyKey, $this->expireTimeInSeconds);
+
+        return $result === 1 ? $value : unserialize(
+            (string)$this->predis->get($idempotencyKey)
+        );
+    }
+}

--- a/src/ConnectFour/Port/Adapter/Messaging/RefereeConsumer.php
+++ b/src/ConnectFour/Port/Adapter/Messaging/RefereeConsumer.php
@@ -68,6 +68,7 @@ final class RefereeConsumer implements Consumer
                 new MessageName('Chat', 'InitiateChat'),
                 json_encode(
                     [
+                        'idempotencyKey' => 'connect-four.' . $payload['gameId'],
                         'correlationId' => $payload['gameId'],
                         'authors' => []
                     ],

--- a/tests/unit/Chat/Application/ChatServiceTest.php
+++ b/tests/unit/Chat/Application/ChatServiceTest.php
@@ -12,10 +12,11 @@ use Gaming\Chat\Application\Command\WriteMessageCommand;
 use Gaming\Chat\Application\Event\ChatInitiated;
 use Gaming\Chat\Application\Event\MessageWritten;
 use Gaming\Chat\Application\Exception\AuthorNotAllowedException;
+use Gaming\Chat\Application\Exception\ChatAlreadyExistsException;
 use Gaming\Chat\Application\Exception\EmptyMessageException;
 use Gaming\Chat\Application\Query\MessagesQuery;
-use Gaming\Common\EventStore\EventStore;
 use Gaming\Common\EventStore\InMemoryEventStore;
+use Gaming\Common\IdempotentStorage\InMemoryIdempotentStorage;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Clock\MockClock;
 
@@ -24,37 +25,47 @@ final class ChatServiceTest extends TestCase
     /**
      * @test
      */
-    public function itShouldInitiateChat(): void
+    public function itShouldInitiateChatExactlyOnce(): void
     {
-        $generatedChatId = ChatId::generate();
+        $expectedChatId = ChatId::generate();
         $authors = ['authorId1', 'authorId2'];
 
         $chatGateway = $this->createMock(ChatGateway::class);
         $chatGateway
-            ->expects($this->once())
+            ->expects($this->exactly(2))
+            ->method('nextIdentity')
+            ->willReturnOnConsecutiveCalls($expectedChatId, ChatId::generate());
+        $chatGateway
+            ->expects($this->exactly(2))
             ->method('create')
-            ->with($authors)
-            ->willReturn($generatedChatId);
+            ->with($expectedChatId, $authors)
+            ->willReturnOnConsecutiveCalls(null, $this->throwException(new ChatAlreadyExistsException()));
 
         $eventStore = new InMemoryEventStore(new MockClock());
 
-        /** @var ChatGateway $chatGateway */
         $chatService = new ChatService(
             $chatGateway,
             $eventStore,
-            new MockClock()
+            new MockClock(),
+            new InMemoryIdempotentStorage()
         );
 
         $chatId = $chatService->initiateChat(
-            new InitiateChatCommand($authors)
+            new InitiateChatCommand('idempotency-key', $authors)
         );
-        $this->assertSame($generatedChatId->toString(), $chatId);
+        $this->assertSame($expectedChatId->toString(), $chatId);
 
-        $storedEvents = $eventStore->byAggregateId($generatedChatId->toString());
+        // Retry with the same idempotency key. The chat id should be the same.
+        $chatId = $chatService->initiateChat(
+            new InitiateChatCommand('idempotency-key', $authors)
+        );
+        $this->assertSame($expectedChatId->toString(), $chatId);
+
+        $storedEvents = $eventStore->byAggregateId($expectedChatId->toString());
         self::assertCount(1, $storedEvents);
 
         assert($storedEvents[0]->domainEvent() instanceof ChatInitiated);
-        self::assertEquals($generatedChatId->toString(), $storedEvents[0]->domainEvent()->aggregateId());
+        self::assertEquals($expectedChatId->toString(), $storedEvents[0]->domainEvent()->aggregateId());
     }
 
     /**
@@ -64,15 +75,11 @@ final class ChatServiceTest extends TestCase
     {
         $this->expectException(EmptyMessageException::class);
 
-        $chatGateway = $this->createMock(ChatGateway::class);
-        $eventStore = $this->createMock(EventStore::class);
-
-        /** @var ChatGateway $chatGateway */
-        /** @var EventStore $eventStore */
         $chatService = new ChatService(
-            $chatGateway,
-            $eventStore,
-            new MockClock()
+            $this->createMock(ChatGateway::class),
+            new InMemoryEventStore(new MockClock()),
+            new MockClock(),
+            new InMemoryIdempotentStorage()
         );
 
         // Test also if trim is performed.
@@ -96,20 +103,17 @@ final class ChatServiceTest extends TestCase
         $assignedAuthors = json_encode(['authorId1', 'authorId2'], JSON_THROW_ON_ERROR);
 
         $chatGateway = $this->createMock(ChatGateway::class);
-        $eventStore = $this->createMock(EventStore::class);
-
         $chatGateway
             ->expects($this->once())
             ->method('byId')
             ->with($chatId)
             ->willReturn(['chatId' => $chatId, 'authors' => $assignedAuthors]);
 
-        /** @var ChatGateway $chatGateway */
-        /** @var EventStore $eventStore */
         $chatService = new ChatService(
             $chatGateway,
-            $eventStore,
-            new MockClock()
+            new InMemoryEventStore(new MockClock()),
+            new MockClock(),
+            new InMemoryIdempotentStorage()
         );
 
         $chatService->writeMessage(
@@ -148,11 +152,11 @@ final class ChatServiceTest extends TestCase
 
         $eventStore = new InMemoryEventStore($clock);
 
-        /** @var ChatGateway $chatGateway */
         $chatService = new ChatService(
             $chatGateway,
             $eventStore,
-            $clock
+            $clock,
+            new InMemoryIdempotentStorage()
         );
 
         $chatService->writeMessage(
@@ -185,20 +189,17 @@ final class ChatServiceTest extends TestCase
         $limit = 10;
 
         $chatGateway = $this->createMock(ChatGateway::class);
-        $eventStore = $this->createMock(EventStore::class);
-
         $chatGateway
             ->expects($this->once())
             ->method('messages')
             ->with($chatId, $authorId, $offset, $limit)
             ->willReturn(['a', 'a', 'a']);
 
-        /** @var ChatGateway $chatGateway */
-        /** @var EventStore $eventStore */
         $chatService = new ChatService(
             $chatGateway,
-            $eventStore,
-            new MockClock()
+            new InMemoryEventStore(new MockClock()),
+            new MockClock(),
+            new InMemoryIdempotentStorage()
         );
 
         $messages = $chatService->messages(


### PR DESCRIPTION
* Whilst issuing a command to initiate a chat, downstream contexts need to attach an idempotency key that must be globally unique. The chat context will make sure that the same idempotency keys produce the same results. Although idempotent, the chat context is configured to clean up idempotency keys after 1 day. Within that timeframe, duplicates are handled gracefully. That's the SLA for up- and downstreams.
* Create abstraction for an idempotent storage and provide a predis implementation.
* Create new environment variable for predis for the chat context.