### PR TITLE
EventStore depends only on DomainEvent

### DIFF
--- a/src/Common/EventStore/EventStore.php
+++ b/src/Common/EventStore/EventStore.php
@@ -10,10 +10,10 @@ use Gaming\Common\EventStore\Exception\EventStoreException;
 interface EventStore
 {
     /**
-     * @return StoredEvent[]
+     * @return DomainEvent[]
      * @throws EventStoreException
      */
-    public function byAggregateId(string $aggregateId, int $sinceId = 0): array;
+    public function byAggregateId(string $aggregateId): array;
 
     /**
      * @throws EventStoreException

--- a/src/Common/EventStore/InMemoryEventStore.php
+++ b/src/Common/EventStore/InMemoryEventStore.php
@@ -5,36 +5,21 @@ declare(strict_types=1);
 namespace Gaming\Common\EventStore;
 
 use Gaming\Common\Domain\DomainEvent;
-use Psr\Clock\ClockInterface;
 
 final class InMemoryEventStore implements EventStore
 {
     /**
-     * @var StoredEvent[]
+     * @var array<string, DomainEvent[]>
      */
-    private array $storedEvents = [];
+    private array $domainEvents = [];
 
-    public function __construct(
-        private readonly ClockInterface $clock
-    ) {
-    }
-
-    public function byAggregateId(string $aggregateId, int $sinceId = 0): array
+    public function byAggregateId(string $aggregateId): array
     {
-        return array_filter(
-            $this->storedEvents,
-            static function (StoredEvent $storedEvent) use ($aggregateId, $sinceId): bool {
-                return $storedEvent->domainEvent()->aggregateId() === $aggregateId && $storedEvent->id() > $sinceId;
-            }
-        );
+        return $this->domainEvents[$aggregateId] ?? [];
     }
 
     public function append(DomainEvent $domainEvent): void
     {
-        $this->storedEvents[] = new StoredEvent(
-            count($this->storedEvents) + 1,
-            $this->clock->now(),
-            $domainEvent
-        );
+        $this->domainEvents[$domainEvent->aggregateId()][] = $domainEvent;
     }
 }

--- a/src/ConnectFour/Port/Adapter/Persistence/Repository/DoctrineJsonGameRepository.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Repository/DoctrineJsonGameRepository.php
@@ -81,13 +81,13 @@ final class DoctrineJsonGameRepository implements Games, GameFinder
     {
         $this->switchShard($gameId);
 
-        $storedEvents = $this->eventStore->byAggregateId(
+        $domainEvents = $this->eventStore->byAggregateId(
             $gameId->toString()
         ) ?: throw new GameNotFoundException();
 
         $game = new GameQueryModel();
-        foreach ($storedEvents as $storedEvent) {
-            $game->apply($storedEvent->domainEvent());
+        foreach ($domainEvents as $domainEvent) {
+            $game->apply($domainEvent);
         }
 
         return $game;


### PR DESCRIPTION
After the interface segregation of `EventStore` to `PollableEventStore` from #140, there's no need for `EventStore` to depend on `StoredEvent` anymore. The range query by id has been removed. A similar functionality will come back when events can be versioned.

This work is part of https://github.com/marein/php-gaming-website/issues/79.