### PR TITLE
Fix segfault in dev environment

### DIFF
--- a/src/Common/ForkPool/Wait.php
+++ b/src/Common/ForkPool/Wait.php
@@ -14,7 +14,7 @@ final class Wait
 
     public function all(): ForkPool
     {
-        while (($processId = pcntl_wait($status)) !== -1) {
+        while (($processId = $this->waitForNextProcess()) !== -1) {
             $this->processes->remove($processId);
         }
 
@@ -23,7 +23,7 @@ final class Wait
 
     public function any(): ForkPool
     {
-        $this->processes->remove(pcntl_wait($status));
+        $this->processes->remove($this->waitForNextProcess());
 
         return $this->forkPool;
     }
@@ -31,5 +31,10 @@ final class Wait
     public function killAllWhenAnyExits(int $signal): void
     {
         $this->any()->kill($signal)->wait()->all();
+    }
+
+    private function waitForNextProcess(): int
+    {
+        return pcntl_wait($status);
     }
 }


### PR DESCRIPTION
The process removal in `Wait::any()` caused a `segfault` in the `dev environment` when a child process got terminated. The reason is not discovered yet. Adding all parameters, assigning the return value to a variable before passing it to `Processes:remove()` or extracting `pcntl_wait` to a function fixes that issue.