### PR TITLE
Shut down event store dispatcher gracefully

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,7 @@ parameters:
     -
       message: '#^While loop condition is always true\.$#'
       path: **/*.php
-      count: 2
+      count: 1
     -
       message: "#^Property Gaming\\\\Identity\\\\Domain\\\\Model\\\\User\\\\User\\:\\:\\$version is never read, only written\\.$#"
       count: 1

--- a/src/Common/EventStore/Integration/ForkPool/Worker.php
+++ b/src/Common/EventStore/Integration/ForkPool/Worker.php
@@ -19,7 +19,8 @@ final class Worker implements Task
     {
         while ($message = $channel->receive()) {
             match ($message) {
-                'PING' => $channel->send('PONG'),
+                'KEEPALIVE' => true,
+                'STOP' => exit(0),
                 'COMMIT' => $this->handleCommit($channel),
                 default => $this->storedEventSubscriber->handle($message)
             };


### PR DESCRIPTION
On sigterm and sigint, the main process sends a sigterm to the publisher process and waits until all child processes have terminated. After the publisher finishes the current iteration, it sends a final message to the workers to make them stop and exits itself. The workers exit as soon as they receive the final message.