### PR TITLE
Add dynamic page loads

### DIFF
--- a/assets/js/Common/HttpClient.js
+++ b/assets/js/Common/HttpClient.js
@@ -66,7 +66,7 @@ class HttpClient
      */
     redirectTo(url)
     {
-        top.location.href = url;
+        window.app.navigate(url);
     }
 
     /**

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,19 +2,32 @@ import { client } from './Common/HttpClient.js'
 import './Common/NotificationList.js'
 
 window.app = {
+    navigate: url => top.location.href = url,
     loadElements: node => Promise.allSettled([...node.querySelectorAll(':not(:defined)')]
         .filter(n => !window.customElements.get(n.localName))
         .map(n => import(n.localName))),
-    showProgress() {
+    showProgress(delay) {
         document.querySelector('.progress')?.remove();
         let progress = document.createElement('div');
         progress.classList.add('progress');
-        const timeout = setTimeout(() => document.head.after(progress), 250);
+        const timeout = setTimeout(() => document.head.after(progress), delay ?? 250);
         return () => clearTimeout(timeout) || progress.classList.add('progress--finish');
+    },
+    peInit() {
+        if (!window.pe) return window.addEventListener('pe:init', window.app.peInit);
+        window.app.navigate = window.pe.navigate;
     }
 }
 
 client.onError = response => document.querySelector('notification-list').appendMessage(response.message);
+
+window.app.peInit();
+window.addEventListener('pe:click', e => e.detail.a.closest('[data-no-turbolink]') && e.preventDefault());
+window.addEventListener('pe:navigate', e => {
+    e.detail.parsed.push(dom => window.app.loadElements(dom.body));
+    e.detail.succeed.push(() => window.dispatchEvent(new CustomEvent('app:load')));
+    e.detail.finally.push(window.app.showProgress(0));
+});
 
 await window.app.loadElements(document.body).finally(window.app.showProgress());
 

--- a/assets/js/pe.js
+++ b/assets/js/pe.js
@@ -1,0 +1,70 @@
+function render(oldDocument, newDocument) {
+    oldDocument.title = newDocument.title || oldDocument.title;
+    oldDocument.body.replaceWith(newDocument.body);
+    [...oldDocument.body.getElementsByTagName('script')].forEach(n => {
+        const s = oldDocument.createElement('script');
+        s.innerHTML = n.innerHTML;
+        [...n.attributes].forEach(a => s.setAttribute(a.nodeName, a.nodeValue));
+        n.replaceWith(s);
+    });
+}
+
+function scroll(id) {
+    const autofocus = document.querySelector('[autofocus]');
+    if (autofocus) return autofocus.focus();
+    if (!id) return window.scrollTo(0, 0);
+    const element = document.getElementById(id);
+    if (!element) return window.scrollTo(0, 0);
+    element.scrollIntoView();
+}
+
+async function navigate(url, changeHistory) {
+    window.pe.abortController.abort();
+    const abortController = window.pe.abortController = new AbortController();
+
+    const event = new CustomEvent('pe:navigate', {
+        detail: {url, render, fetchOptions: {}, parsed: [], succeed: [], catch: [], finally: []}
+    });
+    window.dispatchEvent(event);
+
+    try {
+        const response = await fetch(url, {
+            signal: abortController.signal,
+            ...event.detail.fetchOptions
+        });
+
+        const dom = new DOMParser().parseFromString(await response.text(), 'text/html');
+        await Promise.all(event.detail.parsed.map(f => f(dom)));
+
+        abortController.signal.throwIfAborted();
+
+        event.detail.render(document, dom);
+
+        const hash = url.split('#')[1];
+        if (changeHistory) history.pushState(null, '', response.url + (hash ? '#' + hash : ''));
+        scroll(hash);
+        await Promise.all(event.detail.succeed.map(f => f()));
+    } catch (e) {
+        await Promise.all(event.detail.catch.map(f => f(e)));
+        throw e;
+    } finally {
+        await Promise.all(event.detail.finally.map(f => f()));
+    }
+}
+
+window.pe = {navigate: url => navigate(url, true), abortController: new AbortController()};
+
+window.addEventListener('popstate', () => navigate(top.location.href, false));
+document.addEventListener('click', e => {
+    if (e.metaKey || e.altKey || e.shiftKey) return;
+    let a = e.target.closest('a');
+    if (!a) return;
+    if (a.protocol !== window.location.protocol || a.host !== window.location.host) return;
+    if (a.hasAttribute('target') || a.hasAttribute('download')) return;
+    if (!window.dispatchEvent(new CustomEvent('pe:click', {detail: {a}, cancelable: true}))) return;
+
+    e.preventDefault();
+    navigate(a.href, true);
+});
+
+window.dispatchEvent(new CustomEvent('pe:init'));

--- a/src/WebInterface/Presentation/Http/View/base.html.twig
+++ b/src/WebInterface/Presentation/Http/View/base.html.twig
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="{{ asset('css/app.css') }}"/>
     <script>if(!HTMLScriptElement.supports||!HTMLScriptElement.supports('importmap')){let t=document.createElement('script');t.setAttribute('async','');t.setAttribute('src','https://ga.jspm.io/npm:es-module-shims@1.8.0/dist/es-module-shims.js');document.currentScript.replaceWith(t)}</script>
     {{ importmap() }}
+    <script type="module" src="{{ asset('js/pe.js') }}"></script>
 </head>
 <body>
 <notification-list></notification-list>


### PR DESCRIPTION
All links on the page are intercepted and checked to see if they're a valid internal link. If so, the page is loaded dynamically via ajax, then all undefined custom elements are loaded to avoid flickering, and then the page is placed in the DOM. The same works for popstate events and programmatic triggers, such as joining a game.