### PR TITLE
Make shards a generic interface

### DIFF
--- a/src/Common/Sharding/Integration/Crc32ModShards.php
+++ b/src/Common/Sharding/Integration/Crc32ModShards.php
@@ -14,11 +14,14 @@ use Gaming\Common\Sharding\Shards;
  * It's therefore not suitable for every use case and should be used with caution.
  * A better alternative would be to use a consistent hashing algorithm,
  * which would reduce the likelihood of values being reassigned to another shard.
+ *
+ * @template T
+ * @implements Shards<T>
  */
 final class Crc32ModShards implements Shards
 {
     /**
-     * @param string[] $shards
+     * @param T[] $shards
      *
      * @throws ShardingException
      */
@@ -30,7 +33,7 @@ final class Crc32ModShards implements Shards
         }
     }
 
-    public function lookup(string $value): string
+    public function lookup(string $value): mixed
     {
         return $this->shards[crc32($value) % count($this->shards)];
     }

--- a/src/Common/Sharding/Shards.php
+++ b/src/Common/Sharding/Shards.php
@@ -6,10 +6,14 @@ namespace Gaming\Common\Sharding;
 
 use Gaming\Common\Sharding\Exception\ShardingException;
 
+/**
+ * @template T
+ */
 interface Shards
 {
     /**
+     * @return T
      * @throws ShardingException
      */
-    public function lookup(string $value): string;
+    public function lookup(string $value): mixed;
 }

--- a/src/ConnectFour/Port/Adapter/Persistence/Repository/DoctrineJsonGameRepository.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Repository/DoctrineJsonGameRepository.php
@@ -21,6 +21,9 @@ use Gaming\ConnectFour\Domain\Game\Games;
 
 final class DoctrineJsonGameRepository implements Games, GameFinder
 {
+    /**
+     * @param Shards<string> $shards
+     */
     public function __construct(
         private readonly Connection $connection,
         private readonly string $tableName,


### PR DESCRIPTION
This allows return types other than strings, e.g. a database connection.