### PR TITLE
Require Docker Compose plugin

### DIFF
--- a/.env
+++ b/.env
@@ -2,36 +2,36 @@
 #          Shared          #
 ############################
 # dev|prod
-APP_ENVIRONMENT=dev
-APP_KERNEL_SECRET=ThisTokenIsNotSoSecretChangeIt
-APP_WAIT_FOR=unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbit-mq:5672,nchan:81
-APP_RABBIT_MQ_DSN=amqp://guest:guest@rabbit-mq:5672?heartbeat=60&prefetchCount=30
+APP_ENVIRONMENT='dev'
+APP_KERNEL_SECRET='ThisTokenIsNotSoSecretChangeIt'
+APP_WAIT_FOR='unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbit-mq:5672,nchan:81'
+APP_RABBIT_MQ_DSN='amqp://guest:guest@rabbit-mq:5672?heartbeat=60&prefetchCount=30'
 
 ############################
 #       Chat Context       #
 ############################
-APP_CHAT_DOCTRINE_DBAL_URL=mysqli://root:password@localhost/chat?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock
-APP_CHAT_RUN_MIGRATIONS=1
-APP_CHAT_PREDIS_CLIENT_URL=redis://redis:6379?persistent=1
+APP_CHAT_DOCTRINE_DBAL_URL='mysqli://root:password@localhost/chat?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock'
+APP_CHAT_RUN_MIGRATIONS='1'
+APP_CHAT_PREDIS_CLIENT_URL='redis://redis:6379?persistent=1'
 
 ############################
 #   Connect Four Context   #
 ############################
-APP_CONNECT_FOUR_DOCTRINE_DBAL_URL=mysqli://root:password@localhost?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock
-APP_CONNECT_FOUR_DOCTRINE_DBAL_DATABASE=connect-four
-APP_CONNECT_FOUR_DOCTRINE_DBAL_SHARDS=connect-four
-APP_CONNECT_FOUR_RUN_MIGRATIONS=1
-APP_CONNECT_FOUR_PREDIS_CLIENT_URL=redis://redis:6379?persistent=1
+APP_CONNECT_FOUR_DOCTRINE_DBAL_URL='mysqli://root:password@localhost?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock'
+APP_CONNECT_FOUR_DOCTRINE_DBAL_DATABASE='connect-four'
+APP_CONNECT_FOUR_DOCTRINE_DBAL_SHARDS='connect-four'
+APP_CONNECT_FOUR_RUN_MIGRATIONS='1'
+APP_CONNECT_FOUR_PREDIS_CLIENT_URL='redis://redis:6379?persistent=1'
 
 ############################
 #     Identity Context     #
 ############################
-APP_IDENTITY_DOCTRINE_DBAL_URL=mysqli://root:password@localhost/identity?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock
-APP_IDENTITY_RUN_MIGRATIONS=1
+APP_IDENTITY_DOCTRINE_DBAL_URL='mysqli://root:password@localhost/identity?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock'
+APP_IDENTITY_RUN_MIGRATIONS='1'
 
 ############################
 #  Web Interface Context   #
 ############################
-APP_WEB_INTERFACE_PREDIS_CLIENT_URL=redis://redis:6379?persistent=1
-APP_WEB_INTERFACE_NCHAN_BASE_URL=http://nchan:81
-APP_WEB_INTERFACE_PUBLISH_TO_BROWSER_SHARDS=1
+APP_WEB_INTERFACE_PREDIS_CLIENT_URL='redis://redis:6379?persistent=1'
+APP_WEB_INTERFACE_NCHAN_BASE_URL='http://nchan:81'
+APP_WEB_INTERFACE_PUBLISH_TO_BROWSER_SHARDS='1'

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ describe what's done to apply these concepts.
 ## Installation and requirements
 
 [Docker](https://www.docker.com)
-and
+with
 [Docker Compose](https://docs.docker.com/compose/)
-for deploying the application.
+plugin for deploying the application.
 
 A modern browser, as this project uses modern features and doesn't polyfill all of them, e.g.
 [Server-sent events](https://caniuse.com/eventsource)
@@ -85,8 +85,8 @@ You can run them as follows.
 ```
 git clone https://github.com/marein/php-gaming-website
 cd php-gaming-website
-docker-compose -f deploy/single-server/docker-compose.yml pull
-docker-compose -f deploy/single-server/docker-compose.yml up
+docker compose -f deploy/single-server/docker-compose.yml pull
+docker compose -f deploy/single-server/docker-compose.yml up
 ```
 
 Or you can try out

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -25,9 +25,11 @@ ARG environment=development
 
 WORKDIR /project
 
-COPY /docker/php-fpm/entrypoint.sh /
+COPY /docker/php-fpm/entrypoint.sh /docker/php-fpm/warmup.sh /
 
 COPY --from=builder /project /project
+
+RUN /warmup.sh
 
 COPY /docker/php-fpm/${environment}.ini /etc/php/8.2/fpm/conf.d/
 

--- a/docker/php-fpm/entrypoint.sh
+++ b/docker/php-fpm/entrypoint.sh
@@ -2,13 +2,6 @@
 
 set -e
 
-bin/console cache:warmup
-
-if [ "${APP_ENVIRONMENT}" = "prod" ]
-then
-    bin/console asset-map:compile
-fi
-
 if [ "${APP_WAIT_FOR}" != "" ]
 then
     wait-for-tcp-server "${APP_WAIT_FOR}" 120

--- a/docker/php-fpm/warmup.sh
+++ b/docker/php-fpm/warmup.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Although environments variables are fake during docker build,
+# make them available for the warmup commands.
+set -a && source /project/.env && set +a
+
+if [ "$environment" = "development" ]
+then
+    bin/console cache:warmup
+else
+    bin/console cache:warmup --env=prod
+    bin/console asset-map:compile --env=prod
+fi

--- a/project
+++ b/project
@@ -43,26 +43,26 @@ help() {
 }
 
 build() {
-    docker-compose pull
-    docker-compose down --volumes
-    docker-compose build --pull
-    docker-compose up -d composer
-    docker cp "$(docker-compose ps -q composer)":/project/vendor ./
-    docker-compose up --remove-orphans
+    docker compose pull
+    docker compose down --volumes
+    docker compose build --pull
+    docker compose up -d composer
+    docker cp "$(docker compose ps -q composer)":/project/vendor ./
+    docker compose up --remove-orphans
 }
 
 up() {
-    docker-compose up
+    docker compose up
 }
 
 down() {
-    docker-compose down
+    docker compose down
 }
 
 composer() {
-    docker-compose up -d composer
-    docker-compose run composer composer "$@"
-    docker cp "$(docker-compose ps -q composer)":/project/vendor ./
+    docker compose up -d composer
+    docker compose run composer composer "$@"
+    docker cp "$(docker compose ps -q composer)":/project/vendor ./
 }
 
 tests() {
@@ -73,24 +73,24 @@ tests() {
 }
 
 unit() {
-    docker-compose run php vendor/bin/codecept run --skip acceptance --coverage-html
+    docker compose run --rm php vendor/bin/codecept run --skip acceptance --coverage-html
 }
 
 sniffer() {
-    docker-compose run php vendor/bin/phpcs
+    docker compose run --rm php vendor/bin/phpcs
 }
 
 analyzer() {
-    docker-compose run php vendor/bin/phpstan analyse
+    docker compose run --rm php vendor/bin/phpstan analyse
 }
 
 acceptance() {
     buildProductionImages
 
-    docker-compose -f docker-compose.ci.yml -p php-gaming-website-ci build --pull
-    docker-compose -f docker-compose.ci.yml -p php-gaming-website-ci up -d
-    docker-compose -f docker-compose.ci.yml -p php-gaming-website-ci run php bash -c 'wait-for-tcp-server php-fpm:80,selenium:4444 120 && vendor/bin/codecept run acceptance'
-    docker-compose -f docker-compose.ci.yml -p php-gaming-website-ci down -v
+    docker compose -f docker-compose.ci.yml -p php-gaming-website-ci build --pull
+    docker compose -f docker-compose.ci.yml -p php-gaming-website-ci up -d
+    docker compose -f docker-compose.ci.yml -p php-gaming-website-ci run --rm php bash -c 'wait-for-tcp-server php-fpm:80,selenium:4444 120 && vendor/bin/codecept run acceptance'
+    docker compose -f docker-compose.ci.yml -p php-gaming-website-ci down -v
 }
 
 buildProductionImages() {


### PR DESCRIPTION
* Rewrite project script to use the plugin.
* Move parts of the app build process back to when images are created. As Docker Compose v2 allows env files to contain quoted variables they can be source'd without too much complexity.
* Remove containers after test runs.