### PR TITLE
Use strong message schema in chat

### DIFF
--- a/assets/js/Common/EventSource.js
+++ b/assets/js/Common/EventSource.js
@@ -34,9 +34,8 @@ customElements.define('event-source', class extends HTMLElement {
     _onMessage(message) {
         this._lastEventId = message.lastEventId;
 
-        let payload = JSON.parse(message.data);
-        let eventName = payload.eventName;
-        delete payload.eventName;
+        let [, eventName, eventData] = message.data.split(/([^:]+):(.*)/);
+        let payload = JSON.parse(eventData);
 
         this.dispatchEvent(new CustomEvent(eventName, {bubbles: true, detail: payload}));
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
       "email": "markusreinhold@icloud.com"
     }
   ],
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://gaming-platform.github.io/satis/"
+    }
+  ],
   "autoload": {
     "psr-4": {
       "Gaming\\": "src/"
@@ -28,6 +34,7 @@
     "doctrine/doctrine-migrations-bundle": "^3.2",
     "doctrine/migrations": "^3.5",
     "doctrine/orm": "^2.12",
+    "gaming-platform/api": "^1.0",
     "jms/serializer": "^3.17",
     "marein/php-nchan-client": "^3.1",
     "marein/symfony-lock-doctrine-migrations-bundle": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1488,16 +1488,16 @@
         },
         {
             "name": "gaming-platform/api",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/gaming-platform/api.git",
-                "reference": "a148f042f46148c81a72dc2272d0bd5f4879deb3"
+                "reference": "031c68801c63dad14a99f07a76156c9a0a486352"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gaming-platform/api/zipball/a148f042f46148c81a72dc2272d0bd5f4879deb3",
-                "reference": "a148f042f46148c81a72dc2272d0bd5f4879deb3",
+                "url": "https://api.github.com/repos/gaming-platform/api/zipball/031c68801c63dad14a99f07a76156c9a0a486352",
+                "reference": "031c68801c63dad14a99f07a76156c9a0a486352",
                 "shasum": ""
             },
             "require": {
@@ -1521,10 +1521,10 @@
             ],
             "description": "API definitions for the platform with generated code in various languages.",
             "support": {
-                "source": "https://github.com/gaming-platform/api/tree/1.0.0",
+                "source": "https://github.com/gaming-platform/api/tree/1.1.0",
                 "issues": "https://github.com/gaming-platform/api/issues"
             },
-            "time": "2024-01-07T13:34:15+00:00"
+            "time": "2024-01-10T11:46:19+00:00"
         },
         {
             "name": "jms/metadata",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ecedc126feccbb8ecaf6e7a34464a220",
+    "content-hash": "0a38c4fe7a835b30c330686f41a3c532",
     "packages": [
         {
             "name": "composer/semver",
@@ -1485,6 +1485,46 @@
                 "source": "https://github.com/doctrine/sql-formatter/tree/1.1.3"
             },
             "time": "2022-05-23T21:33:49+00:00"
+        },
+        {
+            "name": "gaming-platform/api",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gaming-platform/api.git",
+                "reference": "a148f042f46148c81a72dc2272d0bd5f4879deb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gaming-platform/api/zipball/a148f042f46148c81a72dc2272d0bd5f4879deb3",
+                "reference": "a148f042f46148c81a72dc2272d0bd5f4879deb3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-protobuf": "*",
+                "php": "^8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GamingPlatform\\Api\\": "php/GamingPlatform/Api/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Markus Reinhold",
+                    "email": "markusreinhold@icloud.com"
+                }
+            ],
+            "description": "API definitions for the platform with generated code in various languages.",
+            "support": {
+                "source": "https://github.com/gaming-platform/api/tree/1.0.0",
+                "issues": "https://github.com/gaming-platform/api/issues"
+            },
+            "time": "2024-01-07T13:34:15+00:00"
         },
         {
             "name": "jms/metadata",

--- a/config/chat/services/subscriber.yml
+++ b/config/chat/services/subscriber.yml
@@ -5,6 +5,5 @@ services:
         public: false
         arguments:
             - '@gaming.message-broker.gaming-exchange-publisher'
-            - '@chat.normalizer'
         tags:
             - { name: 'chat.stored-event-subscriber', key: 'publish-to-message-broker' }

--- a/src/Chat/Infrastructure/Messaging/CommandMessageHandler.php
+++ b/src/Chat/Infrastructure/Messaging/CommandMessageHandler.php
@@ -9,7 +9,7 @@ use Gaming\Common\Bus\Bus;
 use Gaming\Common\MessageBroker\Context;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\MessageHandler;
-use GamingPlatform\Api\Chat\V1\InitiateChat;
+use GamingPlatform\Api\Chat\V1\ChatV1Factory;
 use GamingPlatform\Api\Chat\V1\InitiateChatResponse;
 
 final class CommandMessageHandler implements MessageHandler
@@ -21,8 +21,7 @@ final class CommandMessageHandler implements MessageHandler
 
     public function handle(Message $message, Context $context): void
     {
-        $request = new InitiateChat();
-        $request->mergeFromString($message->body());
+        $request = ChatV1Factory::createInitiateChat($message->body());
 
         $chatId = $this->commandBus->handle(
             new InitiateChatCommand(

--- a/src/Chat/Infrastructure/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
+++ b/src/Chat/Infrastructure/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\Chat\Infrastructure\Messaging;
 
-use Gaming\Chat\Application\Event\ChatInitiated;
+use DateTimeInterface;
 use Gaming\Chat\Application\Event\MessageWritten;
-use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\Publisher;
-use Gaming\Common\Normalizer\Normalizer;
-use RuntimeException;
 
 final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventSubscriber
 {
     public function __construct(
-        private readonly Publisher $publisher,
-        private readonly Normalizer $normalizer
+        private readonly Publisher $publisher
     ) {
     }
 
@@ -26,26 +22,10 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
     {
         $domainEvent = $storedEvent->domainEvent();
 
-        // We should definitely filter the events we are going to publish,
-        // since that belongs to our public interface for the other contexts.
-        // However, it's not done for simplicity in this sample project.
-        // We could
-        //     * publish specific messages by name.
-        //     * filter out specific properties in the payload.
-        //     * translate when the properties for an event in the payload changed.
-        //
-        // We could use a strong message format like json schema, protobuf etc. to have
-        // a clearly defined interface with other domains.
-        $this->publisher->send(
-            new Message(
-                'Chat.' . $this->nameFromDomainEvent($domainEvent),
-                json_encode(
-                    $this->normalizer->normalize($domainEvent, $domainEvent::class),
-                    JSON_THROW_ON_ERROR
-                ),
-                $domainEvent->aggregateId()
-            )
-        );
+        match ($domainEvent::class) {
+            MessageWritten::class => $this->handleMessageWritten($domainEvent),
+            default => true
+        };
     }
 
     public function commit(): void
@@ -53,12 +33,20 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
         $this->publisher->flush();
     }
 
-    private function nameFromDomainEvent(DomainEvent $domainEvent): string
+    public function handleMessageWritten(MessageWritten $event): void
     {
-        return match ($domainEvent::class) {
-            ChatInitiated::class => 'ChatInitiated',
-            MessageWritten::class => 'MessageWritten',
-            default => throw new RuntimeException($domainEvent::class . ' must be handled.')
-        };
+        $this->publisher->send(
+            new Message(
+                'Chat.MessageWritten',
+                (new \GamingPlatform\Api\Chat\V1\MessageWritten())
+                    ->setChatId($event->aggregateId())
+                    ->setMessageId((string)$event->messageId())
+                    ->setAuthorId($event->authorId())
+                    ->setWrittenAt($event->writtenAt()->format(DateTimeInterface::ATOM))
+                    ->setMessage($event->message())
+                    ->serializeToString(),
+                $event->aggregateId()
+            )
+        );
     }
 }

--- a/src/Chat/Infrastructure/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
+++ b/src/Chat/Infrastructure/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
@@ -33,7 +33,7 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
         $this->publisher->flush();
     }
 
-    public function handleMessageWritten(MessageWritten $event): void
+    private function handleMessageWritten(MessageWritten $event): void
     {
         $this->publisher->send(
             new Message(

--- a/src/ConnectFour/Port/Adapter/Messaging/RefereeMessageHandler.php
+++ b/src/ConnectFour/Port/Adapter/Messaging/RefereeMessageHandler.php
@@ -9,6 +9,8 @@ use Gaming\Common\MessageBroker\Context;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\MessageHandler;
 use Gaming\ConnectFour\Application\Game\Command\AssignChatCommand;
+use GamingPlatform\Api\Chat\V1\InitiateChat;
+use GamingPlatform\Api\Chat\V1\InitiateChatResponse;
 
 final class RefereeMessageHandler implements MessageHandler
 {
@@ -19,44 +21,38 @@ final class RefereeMessageHandler implements MessageHandler
 
     public function handle(Message $message, Context $context): void
     {
-        $payload = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
         match ($message->name()) {
-            'Chat.InitiateChatResponse' => $this->handleInitiateChatResponse($payload),
-            'ConnectFour.PlayerJoined' => $this->handlePlayerJoined($payload, $context),
+            'Chat.InitiateChatResponse' => $this->handleInitiateChatResponse($message),
+            'ConnectFour.PlayerJoined' => $this->handlePlayerJoined($message, $context),
             default => true
         };
     }
 
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function handleInitiateChatResponse(array $payload): void
+    private function handleInitiateChatResponse(Message $message): void
     {
+        $response = new InitiateChatResponse();
+        $response->mergeFromString($message->body());
+
         $this->commandBus->handle(
             new AssignChatCommand(
-                $payload['correlationId'],
-                $payload['chatId']
+                $response->getCorrelationId(),
+                $response->getChatId()
             )
         );
     }
 
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function handlePlayerJoined(array $payload, Context $context): void
+    private function handlePlayerJoined(Message $message, Context $context): void
     {
+        $payload = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
         $context->request(
             new Message(
                 'Chat.InitiateChat',
-                json_encode(
-                    [
-                        'idempotencyKey' => 'connect-four.' . $payload['gameId'],
-                        'correlationId' => $payload['gameId'],
-                        'authors' => []
-                    ],
-                    JSON_THROW_ON_ERROR
-                )
+                (new InitiateChat())
+                    ->setIdempotencyKey('connect-four.' . $payload['gameId'])
+                    ->setCorrelationId($payload['gameId'])
+                    ->setAuthors([])
+                    ->serializeToString()
             )
         );
     }

--- a/src/ConnectFour/Port/Adapter/Messaging/RefereeMessageHandler.php
+++ b/src/ConnectFour/Port/Adapter/Messaging/RefereeMessageHandler.php
@@ -9,8 +9,8 @@ use Gaming\Common\MessageBroker\Context;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\MessageHandler;
 use Gaming\ConnectFour\Application\Game\Command\AssignChatCommand;
+use GamingPlatform\Api\Chat\V1\ChatV1Factory;
 use GamingPlatform\Api\Chat\V1\InitiateChat;
-use GamingPlatform\Api\Chat\V1\InitiateChatResponse;
 
 final class RefereeMessageHandler implements MessageHandler
 {
@@ -30,8 +30,7 @@ final class RefereeMessageHandler implements MessageHandler
 
     private function handleInitiateChatResponse(Message $message): void
     {
-        $response = new InitiateChatResponse();
-        $response->mergeFromString($message->body());
+        $response = ChatV1Factory::createInitiateChatResponse($message->body());
 
         $this->commandBus->handle(
             new AssignChatCommand(

--- a/src/WebInterface/Application/BrowserNotifier.php
+++ b/src/WebInterface/Application/BrowserNotifier.php
@@ -9,5 +9,5 @@ interface BrowserNotifier
     /**
      * @param string[] $channels
      */
-    public function publish(array $channels, string $message): void;
+    public function publish(array $channels, string $name, string $message): void;
 }

--- a/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
+++ b/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
@@ -8,7 +8,7 @@ use Gaming\Common\MessageBroker\Context;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\MessageHandler;
 use Gaming\WebInterface\Application\BrowserNotifier;
-use GamingPlatform\Api\Chat\V1\MessageWritten;
+use GamingPlatform\Api\Chat\V1\ChatV1Factory;
 
 final class PublishMessageBrokerEventsToBrowserMessageHandler implements MessageHandler
 {
@@ -40,20 +40,12 @@ final class PublishMessageBrokerEventsToBrowserMessageHandler implements Message
                 $message->name(),
                 $message->body()
             ),
-            'Chat.MessageWritten' => $this->handleMessageWritten($message),
+            'Chat.MessageWritten' => $this->browserNotifier->publish(
+                ['chat-' . $message->streamId()],
+                $message->name(),
+                ChatV1Factory::createMessageWritten($message->body())->serializeToJsonString()
+            ),
             default => true
         };
-    }
-
-    private function handleMessageWritten(Message $message): void
-    {
-        $event = new MessageWritten();
-        $event->mergeFromString($message->body());
-
-        $this->browserNotifier->publish(
-            ['chat-' . $message->streamId()],
-            $message->name(),
-            $event->serializeToJsonString()
-        );
     }
 }

--- a/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
+++ b/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
@@ -8,6 +8,7 @@ use Gaming\Common\MessageBroker\Context;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\MessageHandler;
 use Gaming\WebInterface\Application\BrowserNotifier;
+use GamingPlatform\Api\Chat\V1\MessageWritten;
 
 final class PublishMessageBrokerEventsToBrowserMessageHandler implements MessageHandler
 {
@@ -18,34 +19,113 @@ final class PublishMessageBrokerEventsToBrowserMessageHandler implements Message
 
     public function handle(Message $message, Context $context): void
     {
-        $payload = array_merge(
-            json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR),
-            ['eventName' => $message->name()]
-        );
-        $json = json_encode($payload, JSON_THROW_ON_ERROR);
-
         match ($message->name()) {
-            'ConnectFour.GameOpened', 'ConnectFour.GameAborted' => $this->browserNotifier->publish(
-                ['lobby'],
-                $json
-            ),
-            'ConnectFour.GameResigned',
-            'ConnectFour.GameWon',
-            'ConnectFour.GameDrawn',
-            'ConnectFour.PlayerMoved',
-            'ConnectFour.ChatAssigned' => $this->browserNotifier->publish(
-                ['connect-four-' . $payload['gameId']],
-                $json
-            ),
-            'ConnectFour.PlayerJoined' => $this->browserNotifier->publish(
-                ['lobby', 'connect-four-' . $payload['gameId']],
-                $json
-            ),
-            'Chat.MessageWritten' => $this->browserNotifier->publish(
-                ['chat-' . $payload['chatId']],
-                $json
-            ),
+            'ConnectFour.GameOpened' => $this->handleGameOpened($message),
+            'ConnectFour.GameAborted' => $this->handleGameAborted($message),
+            'ConnectFour.GameResigned' => $this->handleGameResigned($message),
+            'ConnectFour.GameWon' => $this->handleGameWon($message),
+            'ConnectFour.GameDrawn' => $this->handleGameDrawn($message),
+            'ConnectFour.PlayerMoved' => $this->handlePlayerMoved($message),
+            'ConnectFour.ChatAssigned' => $this->handleChatAssigned($message),
+            'ConnectFour.PlayerJoined' => $this->handlePlayerJoined($message),
+            'Chat.MessageWritten' => $this->handleMessageWritten($message),
             default => true
         };
+    }
+
+    private function handleGameOpened(Message $message): void
+    {
+        $this->browserNotifier->publish(
+            ['lobby'],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleGameAborted(Message $message): void
+    {
+        $this->browserNotifier->publish(
+            ['lobby'],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handlePlayerJoined(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['lobby', 'connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleGameResigned(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleGameWon(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleGameDrawn(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handlePlayerMoved(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleChatAssigned(Message $message): void
+    {
+        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->browserNotifier->publish(
+            ['connect-four-' . $event['gameId']],
+            $message->name(),
+            $message->body()
+        );
+    }
+
+    private function handleMessageWritten(Message $message): void
+    {
+        $event = new MessageWritten();
+        $event->mergeFromString($message->body());
+
+        $this->browserNotifier->publish(
+            ['chat-' . $event->getChatId()],
+            $message->name(),
+            $event->serializeToJsonString()
+        );
     }
 }

--- a/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
+++ b/src/WebInterface/Infrastructure/Messaging/PublishMessageBrokerEventsToBrowserMessageHandler.php
@@ -20,101 +20,29 @@ final class PublishMessageBrokerEventsToBrowserMessageHandler implements Message
     public function handle(Message $message, Context $context): void
     {
         match ($message->name()) {
-            'ConnectFour.GameOpened' => $this->handleGameOpened($message),
-            'ConnectFour.GameAborted' => $this->handleGameAborted($message),
-            'ConnectFour.GameResigned' => $this->handleGameResigned($message),
-            'ConnectFour.GameWon' => $this->handleGameWon($message),
-            'ConnectFour.GameDrawn' => $this->handleGameDrawn($message),
-            'ConnectFour.PlayerMoved' => $this->handlePlayerMoved($message),
-            'ConnectFour.ChatAssigned' => $this->handleChatAssigned($message),
-            'ConnectFour.PlayerJoined' => $this->handlePlayerJoined($message),
+            'ConnectFour.GameOpened',
+            'ConnectFour.GameAborted' => $this->browserNotifier->publish(
+                ['lobby'],
+                $message->name(),
+                $message->body()
+            ),
+            'ConnectFour.GameResigned',
+            'ConnectFour.GameWon',
+            'ConnectFour.GameDrawn',
+            'ConnectFour.PlayerMoved',
+            'ConnectFour.ChatAssigned' => $this->browserNotifier->publish(
+                ['connect-four-' . $message->streamId()],
+                $message->name(),
+                $message->body()
+            ),
+            'ConnectFour.PlayerJoined' => $this->browserNotifier->publish(
+                ['lobby', 'connect-four-' . $message->streamId()],
+                $message->name(),
+                $message->body()
+            ),
             'Chat.MessageWritten' => $this->handleMessageWritten($message),
             default => true
         };
-    }
-
-    private function handleGameOpened(Message $message): void
-    {
-        $this->browserNotifier->publish(
-            ['lobby'],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handleGameAborted(Message $message): void
-    {
-        $this->browserNotifier->publish(
-            ['lobby'],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handlePlayerJoined(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['lobby', 'connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handleGameResigned(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handleGameWon(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handleGameDrawn(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handlePlayerMoved(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
-    }
-
-    private function handleChatAssigned(Message $message): void
-    {
-        $event = json_decode($message->body(), true, 512, JSON_THROW_ON_ERROR);
-
-        $this->browserNotifier->publish(
-            ['connect-four-' . $event['gameId']],
-            $message->name(),
-            $message->body()
-        );
     }
 
     private function handleMessageWritten(Message $message): void
@@ -123,7 +51,7 @@ final class PublishMessageBrokerEventsToBrowserMessageHandler implements Message
         $event->mergeFromString($message->body());
 
         $this->browserNotifier->publish(
-            ['chat-' . $event->getChatId()],
+            ['chat-' . $message->streamId()],
             $message->name(),
             $event->serializeToJsonString()
         );

--- a/src/WebInterface/Infrastructure/NchanBrowserNotifier.php
+++ b/src/WebInterface/Infrastructure/NchanBrowserNotifier.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Gaming\WebInterface\Infrastructure;
 
 use Gaming\WebInterface\Application\BrowserNotifier;
-use Marein\Nchan\Api\Model\JsonMessage;
+use Marein\Nchan\Api\Model\PlainTextMessage;
 use Marein\Nchan\Nchan;
 
 final class NchanBrowserNotifier implements BrowserNotifier
@@ -15,12 +15,12 @@ final class NchanBrowserNotifier implements BrowserNotifier
     ) {
     }
 
-    public function publish(array $channels, string $message): void
+    public function publish(array $channels, string $name, string $message): void
     {
         $this->nchan->channel('/pub?id=' . implode(',', $channels))->publish(
-            new JsonMessage(
+            new PlainTextMessage(
                 '',
-                $message
+                $name . ':' . $message
             )
         );
     }

--- a/src/WebInterface/Presentation/Console/PublishRunningGamesCountToNchanCommand.php
+++ b/src/WebInterface/Presentation/Console/PublishRunningGamesCountToNchanCommand.php
@@ -30,13 +30,8 @@ final class PublishRunningGamesCountToNchanCommand extends Command
             if ($lastRunningGamesCount !== $currentRunningGamesCount) {
                 $this->browserNotifier->publish(
                     ['lobby'],
-                    json_encode(
-                        [
-                            'eventName' => 'ConnectFour.RunningGamesUpdated',
-                            'count' => $currentRunningGamesCount
-                        ],
-                        JSON_THROW_ON_ERROR
-                    )
+                    'ConnectFour.RunningGamesUpdated',
+                    json_encode(['count' => $currentRunningGamesCount], JSON_THROW_ON_ERROR)
                 );
 
                 $lastRunningGamesCount = $currentRunningGamesCount;


### PR DESCRIPTION
This work is part of #117.

All messages from the chat context now use protobuf.
Stop publishing the event `ChatInitiated` as there're currently no consumers.

Also, the SSE protocol changes to `eventName:eventPayload` instead of embedding the event name in the payload to avoid unnecessary decoding and encoding of JSON.