### PR TITLE
Use strong message schema in identity

### DIFF
--- a/config/identity/services/subscriber.yml
+++ b/config/identity/services/subscriber.yml
@@ -13,6 +13,5 @@ services:
         public: false
         arguments:
             - '@gaming.message-broker.gaming-exchange-publisher'
-            - '@identity.normalizer'
         tags:
             - { name: 'identity.stored-event-subscriber', key: 'publish-to-message-broker' }

--- a/src/Identity/Port/Adapter/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
+++ b/src/Identity/Port/Adapter/Messaging/PublishStoredEventsToMessageBrokerSubscriber.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\Identity\Port\Adapter\Messaging;
 
-use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\Publisher;
-use Gaming\Common\Normalizer\Normalizer;
 use Gaming\Identity\Domain\Model\User\Event\UserArrived;
 use Gaming\Identity\Domain\Model\User\Event\UserSignedUp;
-use RuntimeException;
 
 final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventSubscriber
 {
     public function __construct(
-        private readonly Publisher $publisher,
-        private readonly Normalizer $normalizer
+        private readonly Publisher $publisher
     ) {
     }
 
@@ -26,26 +22,11 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
     {
         $domainEvent = $storedEvent->domainEvent();
 
-        // We should definitely filter the events we are going to publish,
-        // since that belongs to our public interface for the other contexts.
-        // However, it's not done for simplicity in this sample project.
-        // We could
-        //     * publish specific messages by name.
-        //     * filter out specific properties in the payload.
-        //     * translate when the properties for an event in the payload changed.
-        //
-        // We could use a strong message format like json schema, protobuf etc. to have
-        // a clearly defined interface with other domains.
-        $this->publisher->send(
-            new Message(
-                'Identity.' . $this->nameFromDomainEvent($domainEvent),
-                json_encode(
-                    $this->normalizer->normalize($domainEvent, $domainEvent::class),
-                    JSON_THROW_ON_ERROR
-                ),
-                $domainEvent->aggregateId()
-            )
-        );
+        match ($domainEvent::class) {
+            UserArrived::class => $this->handleUserArrived($domainEvent),
+            UserSignedUp::class => $this->handleUserSignedUp($domainEvent),
+            default => true
+        };
     }
 
     public function commit(): void
@@ -53,12 +34,30 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
         $this->publisher->flush();
     }
 
-    private function nameFromDomainEvent(DomainEvent $domainEvent): string
+    private function handleUserArrived(UserArrived $event): void
     {
-        return match ($domainEvent::class) {
-            UserArrived::class => 'UserArrived',
-            UserSignedUp::class => 'UserSignedUp',
-            default => throw new RuntimeException($domainEvent::class . ' must be handled.')
-        };
+        $this->publisher->send(
+            new Message(
+                'Identity.UserArrived',
+                (new \GamingPlatform\Api\Identity\V1\UserArrived())
+                    ->setUserId($event->aggregateId())
+                    ->serializeToString(),
+                $event->aggregateId()
+            )
+        );
+    }
+
+    private function handleUserSignedUp(UserSignedUp $event): void
+    {
+        $this->publisher->send(
+            new Message(
+                'Identity.UserSignedUp',
+                (new \GamingPlatform\Api\Identity\V1\UserSignedUp())
+                    ->setUserId($event->aggregateId())
+                    ->setUsername($event->username())
+                    ->serializeToString(),
+                $event->aggregateId()
+            )
+        );
     }
 }


### PR DESCRIPTION
This work is part of #117.

All messages from the identity context now use protobuf.