### PR TITLE
Move RabbitMQ image to organization

### DIFF
--- a/.env
+++ b/.env
@@ -4,8 +4,8 @@
 # dev|prod
 APP_ENVIRONMENT='dev'
 APP_KERNEL_SECRET='ThisTokenIsNotSoSecretChangeIt'
-APP_WAIT_FOR='unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbit-mq:5672,nchan:81'
-APP_RABBIT_MQ_DSN='amqp://guest:guest@rabbit-mq:5672?heartbeat=60&prefetchCount=30'
+APP_WAIT_FOR='unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbitmq:5672,nchan:81'
+APP_RABBIT_MQ_DSN='amqp://guest:guest@rabbitmq:5672?heartbeat=60&prefetchCount=30'
 
 ############################
 #       Chat Context       #

--- a/deploy/single-server/docker-compose.yml
+++ b/deploy/single-server/docker-compose.yml
@@ -8,8 +8,8 @@ x-php-container:
     environment:
         APP_ENVIRONMENT: "prod"
         APP_KERNEL_SECRET: "ThisTokenIsNotSoSecretChangeIt"
-        APP_WAIT_FOR: "unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbit-mq:5672,nchan:81"
-        APP_RABBIT_MQ_DSN: "amqp://guest:guest@rabbit-mq:5672?heartbeat=60&prefetchCount=30"
+        APP_WAIT_FOR: "unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbitmq:5672,nchan:81"
+        APP_RABBIT_MQ_DSN: "amqp://guest:guest@rabbitmq:5672?heartbeat=60&prefetchCount=30"
         APP_CHAT_DOCTRINE_DBAL_URL: "mysqli://root:password@localhost/chat?persistent=1&unix_socket=/var/run/proxysql/proxysql.sock"
         APP_CHAT_RUN_MIGRATIONS: "1"
         APP_CHAT_PREDIS_CLIENT_URL: "redis://redis:6379?persistent=1"
@@ -27,7 +27,7 @@ x-php-container:
         - mysql
         - proxysql
         - redis
-        - rabbit-mq
+        - rabbitmq
         - nchan
     volumes:
         - proxysql.sock:/var/run/proxysql
@@ -130,11 +130,11 @@ services:
         labels:
             - "prometheus-job=redis"
             - "prometheus-port=9121"
-    rabbit-mq:
-        image: marein/php-gaming-website:rabbit-mq
-        hostname: rabbit-mq
+    rabbitmq:
+        image: ghcr.io/gaming-platform/docker-rabbitmq:3.12
+        hostname: rabbitmq
         volumes:
-            - rabbit-mq:/var/lib/rabbitmq/mnesia
+            - rabbitmq:/var/lib/rabbitmq/mnesia
         labels:
             - "prometheus-job=rabbitmq"
             - "prometheus-port=15692"
@@ -176,5 +176,5 @@ volumes:
     mysql:
     proxysql.sock:
     redis:
-    rabbit-mq:
+    rabbitmq:
     prometheus:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -10,7 +10,7 @@ x-php-container:
         - mysql
         - proxysql
         - redis
-        - rabbit-mq
+        - rabbitmq
         - nchan
     volumes:
         - proxysql.sock:/var/run/proxysql
@@ -67,11 +67,11 @@ services:
         volumes:
             - redis:/data
         restart: on-failure
-    rabbit-mq:
-        image: marein/php-gaming-website:rabbit-mq
-        hostname: rabbit-mq
+    rabbitmq:
+        image: ghcr.io/gaming-platform/docker-rabbitmq:3.12
+        hostname: rabbitmq
         volumes:
-            - rabbit-mq:/var/lib/rabbitmq/mnesia
+            - rabbitmq:/var/lib/rabbitmq/mnesia
         restart: on-failure
     nchan:
         image: marein/php-gaming-website:nchan
@@ -129,4 +129,4 @@ volumes:
     mysql:
     proxysql.sock:
     redis:
-    rabbit-mq:
+    rabbitmq:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-php-container:
         - mysql
         - proxysql
         - redis
-        - rabbit-mq
+        - rabbitmq
         - nchan
     restart: on-failure
 
@@ -134,13 +134,11 @@ services:
         labels:
             - "prometheus-job=redis"
             - "prometheus-port=9121"
-    rabbit-mq:
-        build:
-            context: .
-            dockerfile: ./docker/rabbit-mq/Dockerfile
-        hostname: rabbit-mq
+    rabbitmq:
+        image: ghcr.io/gaming-platform/docker-rabbitmq:3.12
+        hostname: rabbitmq
         volumes:
-            - rabbit-mq:/var/lib/rabbitmq/mnesia
+            - rabbitmq:/var/lib/rabbitmq/mnesia
         labels:
             - "prometheus-job=rabbitmq"
             - "prometheus-port=15692"
@@ -218,5 +216,5 @@ volumes:
     mysql:
     proxysql.sock:
     redis:
-    rabbit-mq:
+    rabbitmq:
     prometheus:

--- a/docker/rabbit-mq/Dockerfile
+++ b/docker/rabbit-mq/Dockerfile
@@ -1,3 +1,0 @@
-FROM rabbitmq:3.12-alpine
-
-RUN rabbitmq-plugins enable rabbitmq_consistent_hash_exchange

--- a/project
+++ b/project
@@ -98,7 +98,6 @@ buildProductionImages() {
     docker build --file docker/traefik/Dockerfile --tag marein/php-gaming-website:traefik .
     docker build --file docker/nchan/Dockerfile --tag marein/php-gaming-website:nchan .
     docker build --file docker/redis/Dockerfile --tag marein/php-gaming-website:redis .
-    docker build --file docker/rabbit-mq/Dockerfile --tag marein/php-gaming-website:rabbit-mq .
     docker build --file docker/grafana/Dockerfile --tag marein/php-gaming-website:grafana .
     docker build --file docker/prometheus/Dockerfile --tag marein/php-gaming-website:prometheus .
 }
@@ -110,7 +109,6 @@ pushProductionImages() {
     docker push marein/php-gaming-website:traefik
     docker push marein/php-gaming-website:nchan
     docker push marein/php-gaming-website:redis
-    docker push marein/php-gaming-website:rabbit-mq
     docker push marein/php-gaming-website:grafana
     docker push marein/php-gaming-website:prometheus
 }


### PR DESCRIPTION
This work is part of #209.

Pin RabbitMQ to version 3.12 and rename container to rabbitmq.