### PR TITLE
Use colon as key separator in Redis

### DIFF
--- a/config/chat/services/persistence.yml
+++ b/config/chat/services/persistence.yml
@@ -5,7 +5,7 @@ services:
         public: false
         arguments:
             - '%env(APP_CHAT_PREDIS_CLIENT_URL)%'
-            - { prefix: 'chat.' }
+            - { prefix: 'chat:' }
 
     chat.doctrine-dbal:
         alias: 'doctrine.dbal.chat_connection'

--- a/config/connect-four/services/game.yml
+++ b/config/connect-four/services/game.yml
@@ -32,7 +32,7 @@ services:
         public: false
         arguments:
             - '@connect-four.predis'
-            - 'game.'
+            - 'game:'
             - '@connect-four.normalizer'
             - '@connect-four.game-repository'
 
@@ -41,7 +41,7 @@ services:
         public: false
         arguments:
             - '@connect-four.predis'
-            - 'games-by-player.'
+            - 'games-by-player:'
 
     connect-four.open-game-store:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\PredisOpenGameStore

--- a/config/connect-four/services/persistence.yml
+++ b/config/connect-four/services/persistence.yml
@@ -5,8 +5,7 @@ services:
         public: false
         arguments:
             - '%env(APP_CONNECT_FOUR_PREDIS_CLIENT_URL)%'
-            -
-                prefix: 'connect-four.'
+            - { prefix: 'connect-four:' }
 
     connect-four.doctrine-dbal:
         alias: 'doctrine.dbal.connect_four_connection'

--- a/config/web-interface/services/persistence.yml
+++ b/config/web-interface/services/persistence.yml
@@ -5,12 +5,11 @@ services:
         public: false
         arguments:
             - '%env(APP_WEB_INTERFACE_PREDIS_CLIENT_URL)%'
-            -
-                prefix: 'web-interface.'
+            - { prefix: 'web-interface:' }
 
     web-interface.session-handler:
         class: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
         public: false
         arguments:
             - '@web-interface.predis'
-            - { prefix: 'session_', ttl: 86400 }
+            - { prefix: 'session:', ttl: 86400 }


### PR DESCRIPTION
This is actually a standard. Also `phpRedisAdmin` displays keys in a directory structure this way.