### PR TITLE
Use Redis pipelining for projections

### DIFF
--- a/src/ConnectFour/Application/Game/Query/Model/Game/GameStore.php
+++ b/src/ConnectFour/Application/Game/Query/Model/Game/GameStore.php
@@ -12,5 +12,15 @@ namespace Gaming\ConnectFour\Application\Game\Query\Model\Game;
  */
 interface GameStore extends GameFinder
 {
-    public function save(Game $game): void;
+    /**
+     * Queues up the game for persistence. Once queued, it's stored in the database by calling flush.
+     *
+     * Implementations may choose to flush at any given point in time, such as when the queue becomes too large.
+     */
+    public function persist(Game $game): void;
+
+    /**
+     * Flushes all queued up games to the database.
+     */
+    public function flush(): void;
 }

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/GameProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/GameProjection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Port\Adapter\Persistence\Projection;
 
-use Gaming\Common\EventStore\NoCommit;
 use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
@@ -15,8 +14,6 @@ use Gaming\ConnectFour\Port\Adapter\Persistence\Repository\InMemoryCacheGameStor
 
 final class GameProjection implements StoredEventSubscriber
 {
-    use NoCommit;
-
     private readonly GameStore $gameStore;
 
     public function __construct(GameStore $gameStore)
@@ -38,6 +35,11 @@ final class GameProjection implements StoredEventSubscriber
 
         $game->apply($domainEvent);
 
-        $this->gameStore->save($game);
+        $this->gameStore->persist($game);
+    }
+
+    public function commit(): void
+    {
+        $this->gameStore->flush();
     }
 }


### PR DESCRIPTION
Only covers the game projection for now because this is the most network intense as it acts on each single event. The rest is just interested in some of them.

This implementation ([without queue deduplication](https://github.com/marein/php-gaming-website/pull/226#discussion_r1562876451)) yields the following results:
| Used subscriber   | Pipeline size | 1 worker    | 3 workers    |
|-------------------|------------|-------------|--------------|
| `game-projection` | 1 - behaviour before this PR | 2900 sets/s | 6050 sets/s  |
| `game-projection` | 16         | 5080 sets/s | 9900 sets/s  |
| `game-projection` | 50         | 5790 sets/s | 11200 sets/s |

Benchmark details:
* Before execution, the database was filled with 6739 games that generated 175424 events.
* All containers were deployed using `/deploy/single-server/docker-compose.yml` on the same machine (cheap VPS with 3 vCPUs, which is why it's not comparable to the results of #99).
* The data is not aggregated. There was only 1 run for each test.

Another benchmark was done with the docker stack described at #170. The number of workers were reduced from 8 to 3, while the game projection was still immediately available. Did go a bit further and added another FPM instance to reach 30k req/s that yielded roughly 31k game updates per second in Redis without a lag. The test was done with a max pipeline size of 32.

With those numbers, the other projections (running games, games by player and open games) don't need the added code complexity (as described in the first paragraph).