### PR TITLE
Speed up group inserts to EventStore

### DIFF
--- a/src/Chat/Application/ChatService.php
+++ b/src/Chat/Application/ChatService.php
@@ -43,9 +43,7 @@ final class ChatService
 
         try {
             $this->chatGateway->create($chatId, $initiateChatCommand->authors());
-            $this->eventStore->append(
-                new ChatInitiated($chatId)
-            );
+            $this->eventStore->append([new ChatInitiated($chatId)]);
         } catch (ChatAlreadyExistsException) {
             // This happens when a command with the same idempotency key is executed more than once.
             // In this case we can safely ignore the exception. However, if we cannot trust our chat id
@@ -84,9 +82,7 @@ final class ChatService
 
         $messageId = $this->chatGateway->createMessage($chatId, $authorId, $message, $writtenAt);
 
-        $this->eventStore->append(
-            new MessageWritten($chatId, $messageId, $authorId, $message, $writtenAt)
-        );
+        $this->eventStore->append([new MessageWritten($chatId, $messageId, $authorId, $message, $writtenAt)]);
     }
 
     /**

--- a/src/Common/EventStore/EventStore.php
+++ b/src/Common/EventStore/EventStore.php
@@ -16,7 +16,9 @@ interface EventStore
     public function byAggregateId(string $aggregateId): array;
 
     /**
+     * @param DomainEvent[] $domainEvents
+     *
      * @throws EventStoreException
      */
-    public function append(DomainEvent $domainEvent): void;
+    public function append(array $domainEvents): void;
 }

--- a/src/Common/EventStore/InMemoryEventStore.php
+++ b/src/Common/EventStore/InMemoryEventStore.php
@@ -18,8 +18,10 @@ final class InMemoryEventStore implements EventStore
         return $this->domainEvents[$aggregateId] ?? [];
     }
 
-    public function append(DomainEvent $domainEvent): void
+    public function append(array $domainEvents): void
     {
-        $this->domainEvents[$domainEvent->aggregateId()][] = $domainEvent;
+        foreach ($domainEvents as $domainEvent) {
+            $this->domainEvents[$domainEvent->aggregateId()][] = $domainEvent;
+        }
     }
 }

--- a/src/ConnectFour/Port/Adapter/Persistence/EventStore/StoreDomainEventsSubscriber.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/EventStore/StoreDomainEventsSubscriber.php
@@ -19,6 +19,6 @@ final class StoreDomainEventsSubscriber implements DomainEventSubscriber
 
     public function handle(DomainEvent $domainEvent): void
     {
-        $this->eventStore->append($domainEvent);
+        $this->eventStore->append([$domainEvent]);
     }
 }

--- a/src/Identity/Port/Adapter/Persistence/EventStore/StoreDomainEventsSubscriber.php
+++ b/src/Identity/Port/Adapter/Persistence/EventStore/StoreDomainEventsSubscriber.php
@@ -19,6 +19,6 @@ final class StoreDomainEventsSubscriber implements DomainEventSubscriber
 
     public function handle(DomainEvent $domainEvent): void
     {
-        $this->eventStore->append($domainEvent);
+        $this->eventStore->append([$domainEvent]);
     }
 }


### PR DESCRIPTION
This work adds to #79.

Multiple events are inserted with a single statement, avoiding unnecessary round trips to the database.