### PR TITLE
Decouple subscribers from StoredEvent

### DIFF
--- a/config/chat/services/persistence.yml
+++ b/config/chat/services/persistence.yml
@@ -17,4 +17,3 @@ services:
             - '@chat.doctrine-dbal'
             - 'event_store'
             - '@chat.normalizer'
-            - '@clock'

--- a/config/chat/services/subscriber.yml
+++ b/config/chat/services/subscriber.yml
@@ -1,7 +1,7 @@
 services:
 
     chat.publish-stored-events-subscriber:
-        class: Gaming\Chat\Infrastructure\Messaging\PublishStoredEventsToMessageBrokerSubscriber
+        class: Gaming\Chat\Infrastructure\Messaging\PublishDomainEventsToMessageBrokerSubscriber
         public: false
         arguments:
             - '@gaming.message-broker.gaming-exchange-publisher'

--- a/config/connect-four/services/persistence.yml
+++ b/config/connect-four/services/persistence.yml
@@ -17,4 +17,3 @@ services:
             - '@connect-four.doctrine-dbal'
             - 'event_store'
             - '@connect-four.normalizer'
-            - '@clock'

--- a/config/connect-four/services/subscriber.yml
+++ b/config/connect-four/services/subscriber.yml
@@ -41,7 +41,7 @@ services:
             - { name: 'connect-four.stored-event-subscriber', key: 'games-by-player-projection' }
 
     connect-four.publish-stored-events-subscriber:
-        class: Gaming\ConnectFour\Port\Adapter\Messaging\PublishStoredEventsToMessageBrokerSubscriber
+        class: Gaming\ConnectFour\Port\Adapter\Messaging\PublishDomainEventsToMessageBrokerSubscriber
         public: false
         arguments:
             - '@gaming.message-broker.gaming-exchange-publisher'

--- a/config/identity/services/persistence.yml
+++ b/config/identity/services/persistence.yml
@@ -13,7 +13,6 @@ services:
             - '@identity.doctrine-dbal'
             - 'event_store'
             - '@identity.normalizer'
-            - '@clock'
 
     identity.orm.publish-domain-events-listener:
         class: Gaming\Common\Domain\Integration\Doctrine\PublishDomainEventsListener

--- a/config/identity/services/subscriber.yml
+++ b/config/identity/services/subscriber.yml
@@ -9,7 +9,7 @@ services:
             - { name: 'identity.domain-event-subscriber' }
 
     identity.publish-stored-events-subscriber:
-        class: Gaming\Identity\Port\Adapter\Messaging\PublishStoredEventsToMessageBrokerSubscriber
+        class: Gaming\Identity\Port\Adapter\Messaging\PublishDomainEventsToMessageBrokerSubscriber
         public: false
         arguments:
             - '@gaming.message-broker.gaming-exchange-publisher'

--- a/src/Chat/Infrastructure/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
+++ b/src/Chat/Infrastructure/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
@@ -6,22 +6,20 @@ namespace Gaming\Chat\Infrastructure\Messaging;
 
 use DateTimeInterface;
 use Gaming\Chat\Application\Event\MessageWritten;
-use Gaming\Common\EventStore\StoredEvent;
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\Publisher;
 
-final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventSubscriber
+final class PublishDomainEventsToMessageBrokerSubscriber implements StoredEventSubscriber
 {
     public function __construct(
         private readonly Publisher $publisher
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         match ($domainEvent::class) {
             MessageWritten::class => $this->handleMessageWritten($domainEvent),
             default => true

--- a/src/Common/EventStore/CompositeStoredEventSubscriber.php
+++ b/src/Common/EventStore/CompositeStoredEventSubscriber.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\Common\EventStore;
 
+use Gaming\Common\Domain\DomainEvent;
+
 final class CompositeStoredEventSubscriber implements StoredEventSubscriber
 {
     /**
@@ -14,10 +16,10 @@ final class CompositeStoredEventSubscriber implements StoredEventSubscriber
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
         foreach ($this->subscribers as $subscriber) {
-            $subscriber->handle($storedEvent);
+            $subscriber->handle($domainEvent);
         }
     }
 

--- a/src/Common/EventStore/EventListener/DebugEvents.php
+++ b/src/Common/EventStore/EventListener/DebugEvents.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Gaming\Common\EventStore\EventListener;
 
-use DateTimeInterface;
 use Gaming\Common\EventStore\Event\EventsCommitted;
 use Gaming\Common\EventStore\Event\EventsFetched;
 use Psr\Log\LoggerInterface;
@@ -23,7 +22,6 @@ final class DebugEvents
                 'Event fetched.',
                 [
                     'id' => $storedEvent->id(),
-                    'occurredOn' => $storedEvent->occurredOn()->format(DateTimeInterface::ATOM),
                     'domainEvent' => $storedEvent->domainEvent()::class,
                     'aggregateId' => $storedEvent->domainEvent()->aggregateId()
                 ]

--- a/src/Common/EventStore/FollowEventStoreDispatcher.php
+++ b/src/Common/EventStore/FollowEventStoreDispatcher.php
@@ -58,7 +58,7 @@ final class FollowEventStoreDispatcher
         }
 
         foreach ($storedEvents as $storedEvent) {
-            $this->storedEventSubscriber->handle($storedEvent);
+            $this->storedEventSubscriber->handle($storedEvent->domainEvent());
         }
 
         $this->storedEventSubscriber->commit();

--- a/src/Common/EventStore/Integration/Doctrine/DoctrineEventStoreSchema.php
+++ b/src/Common/EventStore/Integration/Doctrine/DoctrineEventStoreSchema.php
@@ -16,7 +16,6 @@ final class DoctrineEventStoreSchema
         $table->addColumn('id', Types::BIGINT, ['autoincrement' => true, 'unsigned' => true]);
         $table->addColumn('aggregateId', 'uuid');
         $table->addColumn('event', Types::JSON);
-        $table->addColumn('occurredOn', Types::DATETIME_IMMUTABLE);
 
         $table->setPrimaryKey(['id']);
         $table->addIndex(['aggregateId']);

--- a/src/Common/EventStore/Integration/ForkPool/ForwardToChannelStoredEventSubscriber.php
+++ b/src/Common/EventStore/Integration/ForkPool/ForwardToChannelStoredEventSubscriber.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\Common\EventStore\Integration\ForkPool;
 
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\Exception\EventStoreException;
-use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\ForkPool\Channel\Channel;
 use InvalidArgumentException;
@@ -25,10 +25,10 @@ final class ForwardToChannelStoredEventSubscriber implements StoredEventSubscrib
         }
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $shardId = crc32($storedEvent->domainEvent()->aggregateId()) % count($this->channels);
-        $this->channels[$shardId]->send($storedEvent);
+        $shardId = crc32($domainEvent->aggregateId()) % count($this->channels);
+        $this->channels[$shardId]->send($domainEvent);
     }
 
     public function commit(): void

--- a/src/Common/EventStore/StoredEvent.php
+++ b/src/Common/EventStore/StoredEvent.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Gaming\Common\EventStore;
 
-use DateTimeImmutable;
 use Gaming\Common\Domain\DomainEvent;
 
 final class StoredEvent
 {
     public function __construct(
         private readonly int $id,
-        private readonly DateTimeImmutable $occurredOn,
         private readonly DomainEvent $domainEvent
     ) {
     }
@@ -19,11 +17,6 @@ final class StoredEvent
     public function id(): int
     {
         return $this->id;
-    }
-
-    public function occurredOn(): DateTimeImmutable
-    {
-        return $this->occurredOn;
     }
 
     public function domainEvent(): DomainEvent

--- a/src/Common/EventStore/StoredEventSubscriber.php
+++ b/src/Common/EventStore/StoredEventSubscriber.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Gaming\Common\EventStore;
 
-interface StoredEventSubscriber
-{
-    public function handle(StoredEvent $storedEvent): void;
+use Gaming\Common\Domain\DomainEventSubscriber;
 
+interface StoredEventSubscriber extends DomainEventSubscriber
+{
     public function commit(): void;
 }

--- a/src/ConnectFour/Port/Adapter/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
+++ b/src/ConnectFour/Port/Adapter/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gaming\ConnectFour\Port\Adapter\Messaging;
 
 use Gaming\Common\Domain\DomainEvent;
-use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\Publisher;
@@ -20,7 +19,7 @@ use Gaming\ConnectFour\Domain\Game\Event\PlayerJoined;
 use Gaming\ConnectFour\Domain\Game\Event\PlayerMoved;
 use RuntimeException;
 
-final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventSubscriber
+final class PublishDomainEventsToMessageBrokerSubscriber implements StoredEventSubscriber
 {
     public function __construct(
         private readonly Publisher $publisher,
@@ -28,10 +27,8 @@ final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventS
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         // We should definitely filter the events we are going to publish,
         // since that belongs to our public interface for the other contexts.
         // However, it's not done for simplicity in this sample project.

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/GameProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/GameProjection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Port\Adapter\Persistence\Projection;
 
-use Gaming\Common\EventStore\StoredEvent;
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
 use Gaming\ConnectFour\Application\Game\Query\Model\Game\GameStore;
@@ -24,10 +24,8 @@ final class GameProjection implements StoredEventSubscriber
         );
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         $game = match ($domainEvent::class) {
             GameOpened::class => new Game(),
             default => $this->gameStore->find(GameId::fromString($domainEvent->aggregateId()))

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/GamesByPlayerProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/GamesByPlayerProjection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Port\Adapter\Persistence\Projection;
 
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\NoCommit;
-use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayerStore;
 use Gaming\ConnectFour\Domain\Game\Event\GameAborted;
@@ -20,10 +20,8 @@ final class GamesByPlayerProjection implements StoredEventSubscriber
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         match ($domainEvent::class) {
             PlayerJoined::class => $this->handlePlayerJoined($domainEvent),
             GameAborted::class => $this->handleGameAborted($domainEvent),

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/OpenGamesProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/OpenGamesProjection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Port\Adapter\Persistence\Projection;
 
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\NoCommit;
-use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\OpenGames\OpenGame;
 use Gaming\ConnectFour\Application\Game\Query\Model\OpenGames\OpenGameStore;
@@ -22,10 +22,8 @@ final class OpenGamesProjection implements StoredEventSubscriber
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         match ($domainEvent::class) {
             GameOpened::class => $this->saveGame($domainEvent->aggregateId(), $domainEvent->playerId()),
             GameAborted::class,

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/RunningGamesProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/RunningGamesProjection.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Port\Adapter\Persistence\Projection;
 
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\NoCommit;
-use Gaming\Common\EventStore\StoredEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\RunningGames\RunningGameStore;
 use Gaming\ConnectFour\Domain\Game\Event\GameAborted;
@@ -23,10 +23,8 @@ final class RunningGamesProjection implements StoredEventSubscriber
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         match ($domainEvent::class) {
             PlayerJoined::class => $this->addGame($domainEvent->aggregateId()),
             GameAborted::class,

--- a/src/Identity/Port/Adapter/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
+++ b/src/Identity/Port/Adapter/Messaging/PublishDomainEventsToMessageBrokerSubscriber.php
@@ -4,24 +4,22 @@ declare(strict_types=1);
 
 namespace Gaming\Identity\Port\Adapter\Messaging;
 
-use Gaming\Common\EventStore\StoredEvent;
+use Gaming\Common\Domain\DomainEvent;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\Common\MessageBroker\Message;
 use Gaming\Common\MessageBroker\Publisher;
 use Gaming\Identity\Domain\Model\User\Event\UserArrived;
 use Gaming\Identity\Domain\Model\User\Event\UserSignedUp;
 
-final class PublishStoredEventsToMessageBrokerSubscriber implements StoredEventSubscriber
+final class PublishDomainEventsToMessageBrokerSubscriber implements StoredEventSubscriber
 {
     public function __construct(
         private readonly Publisher $publisher
     ) {
     }
 
-    public function handle(StoredEvent $storedEvent): void
+    public function handle(DomainEvent $domainEvent): void
     {
-        $domainEvent = $storedEvent->domainEvent();
-
         match ($domainEvent::class) {
             UserArrived::class => $this->handleUserArrived($domainEvent),
             UserSignedUp::class => $this->handleUserSignedUp($domainEvent),


### PR DESCRIPTION
This work is part of #79.

Additional changes:
* Remove occurredOn from StoredEvent. This can be handled by DomainEvent headers/metadata which will be added later.