### PR TITLE
Improve type system

### DIFF
--- a/src/Chat/Application/Command/InitiateChatCommand.php
+++ b/src/Chat/Application/Command/InitiateChatCommand.php
@@ -4,7 +4,12 @@ declare(strict_types=1);
 
 namespace Gaming\Chat\Application\Command;
 
-final class InitiateChatCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<string>
+ */
+final class InitiateChatCommand implements Request
 {
     /**
      * @param string[] $authors

--- a/src/Chat/Application/Command/WriteMessageCommand.php
+++ b/src/Chat/Application/Command/WriteMessageCommand.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Gaming\Chat\Application\Command;
 
-final class WriteMessageCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class WriteMessageCommand implements Request
 {
-    private string $chatId;
-
-    private string $authorId;
-
-    private string $message;
-
-    public function __construct(string $chatId, string $authorId, string $message)
-    {
-        $this->chatId = $chatId;
-        $this->authorId = $authorId;
-        $this->message = $message;
+    public function __construct(
+        private readonly string $chatId,
+        private readonly string $authorId,
+        private readonly string $message
+    ) {
     }
 
     public function chatId(): string

--- a/src/Chat/Application/Query/MessagesQuery.php
+++ b/src/Chat/Application/Query/MessagesQuery.php
@@ -4,22 +4,19 @@ declare(strict_types=1);
 
 namespace Gaming\Chat\Application\Query;
 
-final class MessagesQuery
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<array{messageId: string, authorId: string, message: string, writtenAt: string}[]>
+ */
+final class MessagesQuery implements Request
 {
-    private string $chatId;
-
-    private string $authorId;
-
-    private int $offset;
-
-    private int $limit;
-
-    public function __construct(string $chatId, string $authorId, int $offset, int $limit)
-    {
-        $this->chatId = $chatId;
-        $this->authorId = $authorId;
-        $this->offset = $offset;
-        $this->limit = $limit;
+    public function __construct(
+        private readonly string $chatId,
+        private readonly string $authorId,
+        private readonly int $offset,
+        private readonly int $limit
+    ) {
     }
 
     public function chatId(): string

--- a/src/Chat/Infrastructure/Messaging/CommandMessageHandler.php
+++ b/src/Chat/Infrastructure/Messaging/CommandMessageHandler.php
@@ -29,7 +29,6 @@ final class CommandMessageHandler implements MessageHandler
                 iterator_to_array($request->getAuthors())
             )
         );
-        assert(is_string($chatId));
 
         $context->reply(
             new Message(

--- a/src/Common/Bus/Bus.php
+++ b/src/Common/Bus/Bus.php
@@ -6,14 +6,19 @@ namespace Gaming\Common\Bus;
 
 use Exception;
 use Gaming\Common\Bus\Exception\ApplicationException;
-use Gaming\Common\Bus\Exception\MissingHandlerException;
+use Gaming\Common\Bus\Exception\BusException;
 
 interface Bus
 {
     /**
+     * @template TResponse
+     *
+     * @param Request<TResponse> $request
+     *
+     * @return TResponse
      * @throws ApplicationException
-     * @throws MissingHandlerException
+     * @throws BusException
      * @throws Exception Any application based exception
      */
-    public function handle(object $message): mixed;
+    public function handle(Request $request): mixed;
 }

--- a/src/Common/Bus/Exception/BusException.php
+++ b/src/Common/Bus/Exception/BusException.php
@@ -8,4 +8,8 @@ use Exception;
 
 class BusException extends Exception
 {
+    public static function missingHandler(string $requestClass): self
+    {
+        return new self(sprintf('Missing handler for "%s".', $requestClass));
+    }
 }

--- a/src/Common/Bus/Exception/MissingHandlerException.php
+++ b/src/Common/Bus/Exception/MissingHandlerException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Gaming\Common\Bus\Exception;
-
-final class MissingHandlerException extends BusException
-{
-}

--- a/src/Common/Bus/Integration/DoctrineTransactionalBus.php
+++ b/src/Common/Bus/Integration/DoctrineTransactionalBus.php
@@ -6,6 +6,7 @@ namespace Gaming\Common\Bus\Integration;
 
 use Doctrine\DBAL\Connection;
 use Gaming\Common\Bus\Bus;
+use Gaming\Common\Bus\Request;
 
 final class DoctrineTransactionalBus implements Bus
 {
@@ -15,10 +16,10 @@ final class DoctrineTransactionalBus implements Bus
     ) {
     }
 
-    public function handle(object $message): mixed
+    public function handle(Request $request): mixed
     {
         return $this->connection->transactional(
-            fn() => $this->bus->handle($message)
+            fn() => $this->bus->handle($request)
         );
     }
 }

--- a/src/Common/Bus/Integration/SymfonyValidatorBus.php
+++ b/src/Common/Bus/Integration/SymfonyValidatorBus.php
@@ -6,6 +6,7 @@ namespace Gaming\Common\Bus\Integration;
 
 use Gaming\Common\Bus\Bus;
 use Gaming\Common\Bus\Exception\ApplicationException;
+use Gaming\Common\Bus\Request;
 use Gaming\Common\Bus\Violation;
 use Gaming\Common\Bus\ViolationParameter;
 use Symfony\Component\Validator\ConstraintViolationInterface;
@@ -14,19 +15,15 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 final class SymfonyValidatorBus implements Bus
 {
-    private Bus $bus;
-
-    private ValidatorInterface $validator;
-
-    public function __construct(Bus $bus, ValidatorInterface $validator)
-    {
-        $this->bus = $bus;
-        $this->validator = $validator;
+    public function __construct(
+        private readonly Bus $bus,
+        private readonly ValidatorInterface $validator
+    ) {
     }
 
-    public function handle(object $message): mixed
+    public function handle(Request $request): mixed
     {
-        $symfonyViolations = $this->validator->validate($message);
+        $symfonyViolations = $this->validator->validate($request);
 
         if ($symfonyViolations->count() > 0) {
             throw new ApplicationException(
@@ -34,7 +31,7 @@ final class SymfonyValidatorBus implements Bus
             );
         }
 
-        return $this->bus->handle($message);
+        return $this->bus->handle($request);
     }
 
     /**

--- a/src/Common/Bus/Request.php
+++ b/src/Common/Bus/Request.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Bus;
+
+/**
+ * @template TResponse
+ */
+interface Request
+{
+}

--- a/src/Common/Bus/RoutingBus.php
+++ b/src/Common/Bus/RoutingBus.php
@@ -4,31 +4,22 @@ declare(strict_types=1);
 
 namespace Gaming\Common\Bus;
 
-use Gaming\Common\Bus\Exception\MissingHandlerException;
+use Gaming\Common\Bus\Exception\BusException;
 
 final class RoutingBus implements Bus
 {
     /**
-     * @var callable[]
+     * @param callable[] $requestToHandlerMap
      */
-    private array $messageClassToHandlerMap;
-
-    /**
-     * @param callable[] $messageClassToHandlerMap
-     */
-    public function __construct(array $messageClassToHandlerMap)
-    {
-        $this->messageClassToHandlerMap = $messageClassToHandlerMap;
+    public function __construct(
+        private readonly array $requestToHandlerMap
+    ) {
     }
 
-    public function handle(object $message): mixed
+    public function handle(Request $request): mixed
     {
-        $messageClass = get_class($message);
-
-        if (!isset($this->messageClassToHandlerMap[$messageClass])) {
-            throw new MissingHandlerException(sprintf('Given "%s"', $messageClass));
-        }
-
-        return $this->messageClassToHandlerMap[$messageClass]($message);
+        return ($this->requestToHandlerMap[$request::class] ?? throw BusException::missingHandler($request::class))(
+            $request
+        );
     }
 }

--- a/src/Common/Bus/Violation.php
+++ b/src/Common/Bus/Violation.php
@@ -6,23 +6,14 @@ namespace Gaming\Common\Bus;
 
 final class Violation
 {
-    private string $propertyPath;
-
-    private string $identifier;
-
-    /**
-     * @var ViolationParameter[]
-     */
-    private array $parameters;
-
     /**
      * @param ViolationParameter[] $parameters
      */
-    public function __construct(string $propertyPath, string $identifier, array $parameters)
-    {
-        $this->propertyPath = $propertyPath;
-        $this->identifier = $identifier;
-        $this->parameters = $parameters;
+    public function __construct(
+        private readonly string $propertyPath,
+        private readonly string $identifier,
+        private readonly array $parameters
+    ) {
     }
 
     public function propertyPath(): string

--- a/src/Common/Bus/ViolationParameter.php
+++ b/src/Common/Bus/ViolationParameter.php
@@ -6,14 +6,10 @@ namespace Gaming\Common\Bus;
 
 final class ViolationParameter
 {
-    private string $name;
-
-    private bool|int|float|string $value;
-
-    public function __construct(string $name, bool|int|float|string $value)
-    {
-        $this->name = $name;
-        $this->value = $value;
+    public function __construct(
+        private readonly string $name,
+        private readonly bool|int|float|string $value
+    ) {
     }
 
     public function name(): string

--- a/src/ConnectFour/Application/Game/Command/AbortCommand.php
+++ b/src/ConnectFour/Application/Game/Command/AbortCommand.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class AbortCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class AbortCommand implements Request
 {
-    private string $gameId;
-
-    private string $playerId;
-
-    public function __construct(string $gameId, string $playerId)
-    {
-        $this->gameId = $gameId;
-        $this->playerId = $playerId;
+    public function __construct(
+        private readonly string $gameId,
+        private readonly string $playerId
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Command/AssignChatCommand.php
+++ b/src/ConnectFour/Application/Game/Command/AssignChatCommand.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class AssignChatCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class AssignChatCommand implements Request
 {
-    private string $gameId;
-
-    private string $chatId;
-
-    public function __construct(string $gameId, string $chatId)
-    {
-        $this->gameId = $gameId;
-        $this->chatId = $chatId;
+    public function __construct(
+        private readonly string $gameId,
+        private readonly string $chatId
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Command/JoinCommand.php
+++ b/src/ConnectFour/Application/Game/Command/JoinCommand.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class JoinCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class JoinCommand implements Request
 {
-    private string $gameId;
-
-    private string $playerId;
-
-    public function __construct(string $gameId, string $playerId)
-    {
-        $this->gameId = $gameId;
-        $this->playerId = $playerId;
+    public function __construct(
+        private readonly string $gameId,
+        private readonly string $playerId
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Command/MoveCommand.php
+++ b/src/ConnectFour/Application/Game/Command/MoveCommand.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class MoveCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class MoveCommand implements Request
 {
-    private string $gameId;
-
-    private string $playerId;
-
-    private int $column;
-
-    public function __construct(string $gameId, string $playerId, int $column)
-    {
-        $this->gameId = $gameId;
-        $this->playerId = $playerId;
-        $this->column = $column;
+    public function __construct(
+        private readonly string $gameId,
+        private readonly string $playerId,
+        private readonly int $column
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Command/OpenCommand.php
+++ b/src/ConnectFour/Application/Game/Command/OpenCommand.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class OpenCommand
-{
-    private string $playerId;
+use Gaming\Common\Bus\Request;
 
-    public function __construct(string $playerId)
-    {
-        $this->playerId = $playerId;
+/**
+ * @implements Request<string>
+ */
+final class OpenCommand implements Request
+{
+    public function __construct(
+        private readonly string $playerId
+    ) {
     }
 
     public function playerId(): string

--- a/src/ConnectFour/Application/Game/Command/ResignCommand.php
+++ b/src/ConnectFour/Application/Game/Command/ResignCommand.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Command;
 
-final class ResignCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class ResignCommand implements Request
 {
-    private string $gameId;
-
-    private string $playerId;
-
-    public function __construct(string $gameId, string $playerId)
-    {
-        $this->gameId = $gameId;
-        $this->playerId = $playerId;
+    public function __construct(
+        private readonly string $gameId,
+        private readonly string $playerId
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Query/GameQuery.php
+++ b/src/ConnectFour/Application/Game/Query/GameQuery.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Query;
 
-final class GameQuery
-{
-    private string $gameId;
+use Gaming\Common\Bus\Request;
+use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
 
-    public function __construct(string $gameId)
-    {
-        $this->gameId = $gameId;
+/**
+ * @implements Request<Game>
+ */
+final class GameQuery implements Request
+{
+    public function __construct(
+        private readonly string $gameId
+    ) {
     }
 
     public function gameId(): string

--- a/src/ConnectFour/Application/Game/Query/GamesByPlayerQuery.php
+++ b/src/ConnectFour/Application/Game/Query/GamesByPlayerQuery.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Query;
 
-final class GamesByPlayerQuery
-{
-    private string $playerId;
+use Gaming\Common\Bus\Request;
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
 
-    public function __construct(string $playerId)
-    {
-        $this->playerId = $playerId;
+/**
+ * @implements Request<GamesByPlayer>
+ */
+final class GamesByPlayerQuery implements Request
+{
+    public function __construct(
+        private readonly string $playerId
+    ) {
     }
 
     public function playerId(): string

--- a/src/ConnectFour/Application/Game/Query/OpenGamesQuery.php
+++ b/src/ConnectFour/Application/Game/Query/OpenGamesQuery.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Query;
 
-final class OpenGamesQuery
+use Gaming\Common\Bus\Request;
+use Gaming\ConnectFour\Application\Game\Query\Model\OpenGames\OpenGames;
+
+/**
+ * @implements Request<OpenGames>
+ */
+final class OpenGamesQuery implements Request
 {
 }

--- a/src/ConnectFour/Application/Game/Query/RunningGamesQuery.php
+++ b/src/ConnectFour/Application/Game/Query/RunningGamesQuery.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Query;
 
-final class RunningGamesQuery
+use Gaming\Common\Bus\Request;
+use Gaming\ConnectFour\Application\Game\Query\Model\RunningGames\RunningGames;
+
+/**
+ * @implements Request<RunningGames>
+ */
+final class RunningGamesQuery implements Request
 {
 }

--- a/src/ConnectFour/Port/Adapter/Http/GameController.php
+++ b/src/ConnectFour/Port/Adapter/Http/GameController.php
@@ -12,12 +12,8 @@ use Gaming\ConnectFour\Application\Game\Command\OpenCommand;
 use Gaming\ConnectFour\Application\Game\Command\ResignCommand;
 use Gaming\ConnectFour\Application\Game\Query\GameQuery;
 use Gaming\ConnectFour\Application\Game\Query\GamesByPlayerQuery;
-use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GameByPlayer;
-use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
 use Gaming\ConnectFour\Application\Game\Query\Model\OpenGames\OpenGame;
-use Gaming\ConnectFour\Application\Game\Query\Model\OpenGames\OpenGames;
-use Gaming\ConnectFour\Application\Game\Query\Model\RunningGames\RunningGames;
 use Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery;
 use Gaming\ConnectFour\Application\Game\Query\RunningGamesQuery;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -25,22 +21,15 @@ use Symfony\Component\HttpFoundation\Request;
 
 class GameController
 {
-    private Bus $commandBus;
-
-    private Bus $queryBus;
-
     public function __construct(
-        Bus $commandBus,
-        Bus $queryBus
+        private readonly Bus $commandBus,
+        private readonly Bus $queryBus
     ) {
-        $this->commandBus = $commandBus;
-        $this->queryBus = $queryBus;
     }
 
     public function openGamesAction(Request $request): JsonResponse
     {
         $openGames = $this->queryBus->handle(new OpenGamesQuery());
-        assert($openGames instanceof OpenGames);
 
         $games = array_map(
             static fn(OpenGame $openGame): array => [
@@ -60,7 +49,6 @@ class GameController
     public function runningGamesAction(Request $request): JsonResponse
     {
         $runningGames = $this->queryBus->handle(new RunningGamesQuery());
-        assert($runningGames instanceof RunningGames);
 
         return new JsonResponse(
             [
@@ -76,7 +64,6 @@ class GameController
                 (string)$request->query->get('playerId')
             )
         );
-        assert($gamesByPlayer instanceof GamesByPlayer);
 
         $games = array_map(
             static fn(GameByPlayer $openGame): string => $openGame->gameId(),
@@ -97,7 +84,6 @@ class GameController
                 (string)$request->query->get('gameId')
             )
         );
-        assert($game instanceof Game);
 
         return new JsonResponse($game);
     }

--- a/src/Identity/Application/User/Command/ArriveCommand.php
+++ b/src/Identity/Application/User/Command/ArriveCommand.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Gaming\Identity\Application\User\Command;
 
-final class ArriveCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<string>
+ */
+final class ArriveCommand implements Request
 {
 }

--- a/src/Identity/Application/User/Command/SignUpCommand.php
+++ b/src/Identity/Application/User/Command/SignUpCommand.php
@@ -4,19 +4,18 @@ declare(strict_types=1);
 
 namespace Gaming\Identity\Application\User\Command;
 
-final class SignUpCommand
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<void>
+ */
+final class SignUpCommand implements Request
 {
-    private string $userId;
-
-    private string $username;
-
-    private string $password;
-
-    public function __construct(string $userId, string $username, string $password)
-    {
-        $this->userId = $userId;
-        $this->username = $username;
-        $this->password = $password;
+    public function __construct(
+        private readonly string $userId,
+        private readonly string $username,
+        private readonly string $password
+    ) {
     }
 
     public function userId(): string

--- a/src/Identity/Port/Adapter/Persistence/Repository/DoctrineUserRepository.php
+++ b/src/Identity/Port/Adapter/Persistence/Repository/DoctrineUserRepository.php
@@ -36,16 +36,7 @@ final class DoctrineUserRepository implements Users
 
     public function get(UserId $userId): User
     {
-        $repository = $this->manager->getRepository(User::class);
-
-        $user = $repository->find($userId);
-
-        if ($user === null) {
-            throw new UserNotFoundException();
-        }
-
-        assert($user instanceof User);
-
-        return $user;
+        return $this->manager->getRepository(User::class)
+            ->find($userId) ?? throw new UserNotFoundException();
     }
 }

--- a/tests/unit/Common/Bus/RetryBusTest.php
+++ b/tests/unit/Common/Bus/RetryBusTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gaming\Tests\Unit\Common\Bus;
 
 use Gaming\Common\Bus\Bus;
+use Gaming\Common\Bus\Request;
 use Gaming\Common\Bus\RetryBus;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -34,10 +35,6 @@ final class RetryBusTest extends TestCase
      */
     public function itShouldRetry(): void
     {
-        $actionToCall = static function (): void {
-            // No op
-        };
-
         $bus = $this->createMock(Bus::class);
 
         // The first two times when "handle" is called, an exception is thrown.
@@ -61,7 +58,7 @@ final class RetryBusTest extends TestCase
             RuntimeException::class
         );
 
-        $retryBus->handle($actionToCall);
+        $retryBus->handle($this->createRequest());
     }
 
     /**
@@ -93,11 +90,7 @@ final class RetryBusTest extends TestCase
             RuntimeException::class
         );
 
-        $retryBus->handle(
-            static function (): void {
-                // No op
-            }
-        );
+        $retryBus->handle($this->createRequest());
     }
 
     /**
@@ -129,10 +122,12 @@ final class RetryBusTest extends TestCase
             InvalidArgumentException::class
         );
 
-        $retryBus->handle(
-            static function (): void {
-                // No op
-            }
-        );
+        $retryBus->handle($this->createRequest());
+    }
+
+    private function createRequest(): Request
+    {
+        return new class () implements Request {
+        };
     }
 }


### PR DESCRIPTION
Use generics for application requests so that PHPStan and the IDE can derive the types themselves. It adds a dependency on the application layer, but the benefit of a stronger type system outweighs this small tradeoff.

Also apply some new coding standards to touched classes.