### PR TITLE
Call identity context in UserProvider

### DIFF
--- a/config/identity/config.yml
+++ b/config/identity/config.yml
@@ -1,10 +1,5 @@
 imports:
-    - { resource: services/command_bus.yml }
-    - { resource: services/console.yml }
-    - { resource: services/normalizer.yml }
-    - { resource: services/persistence.yml }
-    - { resource: services/subscriber.yml }
-    - { resource: services/user.yml }
+    - { resource: services/ }
 
 framework:
     validation:

--- a/config/identity/services/query_bus.yml
+++ b/config/identity/services/query_bus.yml
@@ -1,0 +1,12 @@
+services:
+
+    identity.query-bus:
+        class: Gaming\Common\Bus\RoutingBus
+        arguments:
+            -
+                'Gaming\Identity\Application\User\Query\UserQuery': [ '@identity.user-service', 'user' ]
+
+    identity.symfony-validator-query-bus:
+        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
+        decorates: identity.query-bus
+        arguments: [ '@.inner', '@validator' ]

--- a/config/web-interface/services/security.yml
+++ b/config/web-interface/services/security.yml
@@ -4,7 +4,6 @@ services:
     class: Gaming\WebInterface\Infrastructure\Security\Security
     arguments:
       - '@security.helper'
-      - '@web-interface.security.user_provider'
 
   web-interface.security.user_provider:
     class: Gaming\WebInterface\Infrastructure\Security\UserProvider

--- a/config/web-interface/services/security.yml
+++ b/config/web-interface/services/security.yml
@@ -3,15 +3,17 @@ services:
   web-interface.security:
     class: Gaming\WebInterface\Infrastructure\Security\Security
     arguments:
-      - '@security.token_storage'
+      - '@security.helper'
+      - '@web-interface.security.user_provider'
 
   web-interface.security.user_provider:
     class: Gaming\WebInterface\Infrastructure\Security\UserProvider
-    public: false
+    arguments:
+      - '@identity.query-bus'
+      - '@clock'
 
   web-interface.security.arrival_authenticator:
     class: Gaming\WebInterface\Infrastructure\Security\ArrivalAuthenticator
-    public: false
     arguments:
       - '@web-interface.identity-service'
       - '@security.token_storage'

--- a/src/Identity/Application/User/Query/User.php
+++ b/src/Identity/Application/User/Query/User.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Identity\Application\User\Query;
+
+final class User
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $username,
+        public readonly bool $isSignedUp
+    ) {
+    }
+}

--- a/src/Identity/Application/User/Query/UserQuery.php
+++ b/src/Identity/Application/User/Query/UserQuery.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Identity\Application\User\Query;
+
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<User>
+ */
+final class UserQuery implements Request
+{
+    public function __construct(
+        public readonly string $userId
+    ) {
+    }
+}

--- a/src/Identity/Application/User/UserService.php
+++ b/src/Identity/Application/User/UserService.php
@@ -6,6 +6,8 @@ namespace Gaming\Identity\Application\User;
 
 use Gaming\Identity\Application\User\Command\ArriveCommand;
 use Gaming\Identity\Application\User\Command\SignUpCommand;
+use Gaming\Identity\Application\User\Query\User as UserResponse;
+use Gaming\Identity\Application\User\Query\UserQuery;
 use Gaming\Identity\Domain\Model\User\Exception\UserAlreadySignedUpException;
 use Gaming\Identity\Domain\Model\User\Exception\UserNotFoundException;
 use Gaming\Identity\Domain\Model\User\User;
@@ -41,5 +43,16 @@ final class UserService
         $user->signUp($command->email, $command->username);
 
         $this->users->save($user);
+    }
+
+    public function user(UserQuery $query): UserResponse
+    {
+        $user = $this->users->get(UserId::fromString($query->userId));
+
+        return new UserResponse(
+            $query->userId,
+            $user->username(),
+            $user->isSignedUp()
+        );
     }
 }

--- a/src/Identity/Domain/Model/User/User.php
+++ b/src/Identity/Domain/Model/User/User.php
@@ -53,7 +53,7 @@ class User implements CollectsDomainEvents
      */
     public function signUp(string $email, string $username): void
     {
-        if ($this->email !== null) {
+        if ($this->isSignedUp()) {
             throw new UserAlreadySignedUpException();
         }
 
@@ -64,6 +64,16 @@ class User implements CollectsDomainEvents
             $this->userId->toString(),
             new UserSignedUp($this->userId, $this->email, $this->username)
         );
+    }
+
+    public function username(): string
+    {
+        return (string)$this->username;
+    }
+
+    public function isSignedUp(): bool
+    {
+        return $this->email !== null && $this->username !== null;
     }
 
     public function flushDomainEvents(): array

--- a/src/WebInterface/Infrastructure/Security/Security.php
+++ b/src/WebInterface/Infrastructure/Security/Security.php
@@ -5,33 +5,21 @@ declare(strict_types=1);
 namespace Gaming\WebInterface\Infrastructure\Security;
 
 use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Uid\NilUuid;
 
 final class Security
 {
-    /**
-     * @param UserProviderInterface<User> $userProvider
-     */
     public function __construct(
-        private readonly SymfonySecurity $security,
-        private readonly UserProviderInterface $userProvider
+        private readonly SymfonySecurity $security
     ) {
     }
 
-    public function getUser(): UserInterface
+    public function getUser(): User
     {
-        return $this->security->getUser() ?? new User(
-            (new NilUuid())->toRfc4122()
-        );
-    }
+        if ($this->security->getUser() instanceof User) {
+            return $this->security->getUser();
+        }
 
-    public function login(string $identifier): ?Response
-    {
-        return $this->security->login(
-            $this->userProvider->loadUserByIdentifier($identifier)
-        );
+        return new User((new NilUuid())->toRfc4122());
     }
 }

--- a/src/WebInterface/Infrastructure/Security/Security.php
+++ b/src/WebInterface/Infrastructure/Security/Security.php
@@ -4,21 +4,34 @@ declare(strict_types=1);
 
 namespace Gaming\WebInterface\Infrastructure\Security;
 
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Bundle\SecurityBundle\Security as SymfonySecurity;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Uid\NilUuid;
 
 final class Security
 {
+    /**
+     * @param UserProviderInterface<User> $userProvider
+     */
     public function __construct(
-        private readonly TokenStorageInterface $tokenStorage
+        private readonly SymfonySecurity $security,
+        private readonly UserProviderInterface $userProvider
     ) {
     }
 
     public function getUser(): UserInterface
     {
-        return $this->tokenStorage->getToken()?->getUser() ?? new User(
+        return $this->security->getUser() ?? new User(
             (new NilUuid())->toRfc4122()
+        );
+    }
+
+    public function login(string $identifier): ?Response
+    {
+        return $this->security->login(
+            $this->userProvider->loadUserByIdentifier($identifier)
         );
     }
 }

--- a/src/WebInterface/Infrastructure/Security/User.php
+++ b/src/WebInterface/Infrastructure/Security/User.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Gaming\WebInterface\Infrastructure\Security;
 
+use DateTimeImmutable;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 final class User implements UserInterface
 {
     public function __construct(
-        private readonly string $userIdentifier
+        private readonly string $userIdentifier,
+        public readonly string $username = '',
+        public readonly bool $isSignedUp = false,
+        public readonly DateTimeImmutable $refreshAt = new DateTimeImmutable()
     ) {
     }
 

--- a/src/WebInterface/Infrastructure/Security/User.php
+++ b/src/WebInterface/Infrastructure/Security/User.php
@@ -13,8 +13,18 @@ final class User implements UserInterface
         private readonly string $userIdentifier,
         public readonly string $username = '',
         public readonly bool $isSignedUp = false,
-        public readonly DateTimeImmutable $refreshAt = new DateTimeImmutable()
+        private DateTimeImmutable $refreshAt = new DateTimeImmutable()
     ) {
+    }
+
+    public function forceRefreshAtNextRequest(): void
+    {
+        $this->refreshAt = new DateTimeImmutable('-1 year');
+    }
+
+    public function refreshAt(): DateTimeImmutable
+    {
+        return $this->refreshAt;
     }
 
     public function getRoles(): array

--- a/src/WebInterface/Infrastructure/Security/UserProvider.php
+++ b/src/WebInterface/Infrastructure/Security/UserProvider.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Gaming\WebInterface\Infrastructure\Security;
 
+use DateInterval;
+use Gaming\Common\Bus\Bus;
+use Gaming\Identity\Application\User\Query\UserQuery;
+use Gaming\Identity\Domain\Model\User\Exception\UserNotFoundException;
+use Psr\Clock\ClockInterface;
+use Symfony\Component\Security\Core\Exception\UserNotFoundException as SymfonyUserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -12,9 +18,25 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
  */
 final class UserProvider implements UserProviderInterface
 {
+    public function __construct(
+        private readonly Bus $identityQueryBus,
+        private readonly ClockInterface $clock,
+        private readonly int $refreshRateInSeconds = 60
+    ) {
+    }
+
+    /**
+     * As this UserProvider is based on an external API, the user is only refreshed at the configured interval.
+     * This can cause the data in the session to be stale, e.g. the username.
+     * If critical data is changed by the user themselves, they must be logged in again programmatically.
+     */
     public function refreshUser(UserInterface $user): UserInterface
     {
-        return $this->loadUserByIdentifier($user->getUserIdentifier());
+        assert($user instanceof User);
+
+        return $user->refreshAt >= $this->clock->now()
+            ? $user
+            : $this->loadUserByIdentifier($user->getUserIdentifier());
     }
 
     public function supportsClass(string $class): bool
@@ -24,6 +46,24 @@ final class UserProvider implements UserProviderInterface
 
     public function loadUserByIdentifier(string $identifier): UserInterface
     {
-        return new User($identifier);
+        try {
+            $user = $this->identityQueryBus->handle(
+                new UserQuery($identifier)
+            );
+
+            return new User(
+                $user->userId,
+                $user->username,
+                $user->isSignedUp,
+                $this->clock->now()->add(new DateInterval('PT' . abs($this->refreshRateInSeconds) . 'S'))
+            );
+        } catch (UserNotFoundException) {
+            $exception = new SymfonyUserNotFoundException(
+                sprintf('There is no user with identifier "%s".', $identifier)
+            );
+            $exception->setUserIdentifier($identifier);
+
+            throw $exception;
+        }
     }
 }

--- a/src/WebInterface/Infrastructure/Security/UserProvider.php
+++ b/src/WebInterface/Infrastructure/Security/UserProvider.php
@@ -28,13 +28,13 @@ final class UserProvider implements UserProviderInterface
     /**
      * As this UserProvider is based on an external API, the user is only refreshed at the configured interval.
      * This can cause the data in the session to be stale, e.g. the username.
-     * If critical data is changed by the user themselves, they must be logged in again programmatically.
+     * If critical data is changed by the user themselves, the security's user must be refreshed manually.
      */
     public function refreshUser(UserInterface $user): UserInterface
     {
         assert($user instanceof User);
 
-        return $user->refreshAt >= $this->clock->now()
+        return $user->refreshAt() >= $this->clock->now()
             ? $user
             : $this->loadUserByIdentifier($user->getUserIdentifier());
     }


### PR DESCRIPTION
This saves the most important user data in the session.

As the UserProvider is based on an external API (not really, but the design is aiming for that), the user is only refreshed at a configured interval (default is 60s). This can cause the data in the session to be stale, e.g. the username. If critical data is changed by the user themselves, the security's user must be refreshed manually.

With a refresh interval of 60s, no performance is lost when testing with #170 (same test scenarios). Even 10s doesn't show any impact. However, 0s shows a loss of ~3k req/s.