### PR TITLE
Clean up service container definitions

### DIFF
--- a/config/chat/config.yml
+++ b/config/chat/config.yml
@@ -1,12 +1,4 @@
-imports:
-    - { resource: services/chat.yml }
-    - { resource: services/command_bus.yml }
-    - { resource: services/console.yml }
-    - { resource: services/consumer.yml }
-    - { resource: services/normalizer.yml }
-    - { resource: services/persistence.yml }
-    - { resource: services/query_bus.yml }
-    - { resource: services/subscriber.yml }
+imports: [{ resource: services/ }]
 
 doctrine:
     dbal:
@@ -16,5 +8,5 @@ doctrine:
                 server_version: '8.2'
                 charset: utf8mb4
                 default_table_options:
-                     charset: utf8mb4
-                     collate: utf8mb4_unicode_ci
+                    charset: utf8mb4
+                    collate: utf8mb4_unicode_ci

--- a/config/chat/services/chat.yml
+++ b/config/chat/services/chat.yml
@@ -1,31 +1,16 @@
 services:
-
     chat.chat-controller:
         class: Gaming\Chat\Presentation\Http\ChatController
-        public: false
-        arguments:
-            - '@chat.command-bus'
-            - '@chat.query-bus'
+        arguments: ['@chat.command-bus', '@chat.query-bus']
 
     chat.chat-gateway:
         class: Gaming\Chat\Infrastructure\DoctrineChatGateway
-        public: false
-        arguments:
-            - '@chat.doctrine-dbal'
-            - 'chat'
-            - 'message'
+        arguments: ['@chat.doctrine-dbal', 'chat', 'message']
 
     chat.idempotent-chat-id-storage:
         class: Gaming\Common\IdempotentStorage\PredisIdempotentStorage
-        arguments:
-            - '@chat.predis'
-            - 86400
+        arguments: ['@chat.predis', 86400]
 
     chat.chat-service:
         class: Gaming\Chat\Application\ChatService
-        public: false
-        arguments:
-            - '@chat.chat-gateway'
-            - '@chat.event-store'
-            - '@clock'
-            - '@chat.idempotent-chat-id-storage'
+        arguments: ['@chat.chat-gateway', '@chat.event-store', '@clock', '@chat.idempotent-chat-id-storage']

--- a/config/chat/services/command_bus.yml
+++ b/config/chat/services/command_bus.yml
@@ -1,25 +1,16 @@
 services:
-
-    # The following definitions decorate the routing command bus. This could be done with a factory object.
     chat.command-bus:
-        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
-        public: false
-        arguments:
-            - '@chat.doctrine-transactional-command-bus'
-            - '@validator'
-
-    chat.doctrine-transactional-command-bus:
-        class: Gaming\Common\Bus\Integration\DoctrineTransactionalBus
-        public: false
-        arguments:
-            - '@chat.routing-command-bus'
-            - '@chat.doctrine-dbal'
-
-    # This is pretty ugly. We can use tags, or create this via a factory in php.
-    chat.routing-command-bus:
         class: Gaming\Common\Bus\RoutingBus
-        public: false
         arguments:
-            -
-                'Gaming\Chat\Application\Command\InitiateChatCommand': ['@chat.chat-service', 'initiateChat']
+            -   'Gaming\Chat\Application\Command\InitiateChatCommand': ['@chat.chat-service', 'initiateChat']
                 'Gaming\Chat\Application\Command\WriteMessageCommand': ['@chat.chat-service', 'writeMessage']
+
+    chat.transactional-command-bus:
+        class: Gaming\Common\Bus\Integration\DoctrineTransactionalBus
+        decorates: 'chat.command-bus'
+        arguments: ['@.inner', '@chat.doctrine-dbal']
+
+    chat.validating-command-bus:
+        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
+        decorates: 'chat.command-bus'
+        arguments: ['@.inner', '@validator']

--- a/config/chat/services/console.yml
+++ b/config/chat/services/console.yml
@@ -1,16 +1,14 @@
 services:
-
     chat.follow-event-store-command:
         class: Gaming\Common\EventStore\Integration\Symfony\FollowEventStoreCommand
-        public: false
         arguments:
             - '@chat.event-store'
             - !service
                 class: Gaming\Common\EventStore\Integration\Doctrine\DoctrineMysqlEventStorePointerFactory
-                arguments:
-                    - '@chat.doctrine-dbal'
-                    - 'event_store_pointer'
+                arguments: ['@chat.doctrine-dbal', 'event_store_pointer']
             - !tagged_locator { tag: 'chat.stored-event-subscriber', index_by: 'key' }
             - '@event_dispatcher'
         tags:
-            - { name: console.command, command: chat:follow-event-store, description: 'Publish events to subscribers.' }
+            -   name: console.command
+                command: chat:follow-event-store
+                description: 'Publish events to subscribers.'

--- a/config/chat/services/consumer.yml
+++ b/config/chat/services/consumer.yml
@@ -1,13 +1,8 @@
 services:
-
     chat.command-message-handler.topology:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\Topology\QueueTopology
-        arguments:
-            - 'Chat.CommandListener'
-            - 'gaming'
-            - ['Chat.InitiateChat']
-        tags:
-            - { name: 'gaming.message-broker.topology' }
+        arguments: ['Chat.CommandListener', 'gaming', ['Chat.InitiateChat']]
+        tags: [{ name: 'gaming.message-broker.topology' }]
 
     chat.command-message-handler.consumer:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\AmqpConsumer
@@ -15,11 +10,8 @@ services:
         arguments:
             - !service
                 class: Gaming\Chat\Infrastructure\Messaging\CommandMessageHandler
-                arguments:
-                    - '@chat.command-bus'
+                arguments: ['@chat.command-bus']
             - !service
                 class: Gaming\Common\MessageBroker\Integration\AmqpLib\QueueConsumer\ConsumeQueues
-                arguments:
-                    - '@chat.command-message-handler.topology'
-        tags:
-            - { name: 'gaming.consumer', key: 'chat.command' }
+                arguments: ['@chat.command-message-handler.topology']
+        tags: [{ name: 'gaming.consumer', key: 'chat.command' }]

--- a/config/chat/services/normalizer.yml
+++ b/config/chat/services/normalizer.yml
@@ -1,5 +1,4 @@
 services:
-
     chat.jms:
         class: JMS\Serializer\Serializer
         factory: ['Gaming\Common\JmsSerializer\JmsSerializerFactory', 'create']
@@ -11,5 +10,4 @@ services:
 
     chat.normalizer:
         class: Gaming\Common\Normalizer\Integration\JmsSerializerNormalizer
-        arguments:
-            - '@chat.jms'
+        arguments: ['@chat.jms']

--- a/config/chat/services/persistence.yml
+++ b/config/chat/services/persistence.yml
@@ -1,23 +1,16 @@
 services:
-
     chat.predis:
         class: Predis\Client
-        public: false
-        arguments:
-            - '%env(APP_CHAT_PREDIS_CLIENT_URL)%'
-            - { prefix: 'chat:' }
+        arguments: ['%env(APP_CHAT_PREDIS_CLIENT_URL)%', { prefix: 'chat:' }]
 
     chat.doctrine-dbal:
         alias: 'doctrine.dbal.chat_connection'
 
     chat.event-store:
         class: Gaming\Common\EventStore\Integration\Doctrine\DoctrineEventStore
-        public: false
         arguments:
             - '@chat.doctrine-dbal'
             - 'event_store'
             - !service
                 class: Gaming\Common\EventStore\Integration\JmsSerializer\JmsContentSerializer
-                arguments:
-                    - '@chat.jms'
-                    - 'Gaming\Common\Domain\DomainEvent'
+                arguments: ['@chat.jms', 'Gaming\Common\Domain\DomainEvent']

--- a/config/chat/services/query_bus.yml
+++ b/config/chat/services/query_bus.yml
@@ -1,16 +1,10 @@
 services:
-
-    # This is pretty ugly. We can use tags, or create this via a factory in php.
     chat.query-bus:
-        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
-        public: false
-        arguments:
-            - '@chat.routing-query-bus'
-            - '@validator'
-
-    chat.routing-query-bus:
         class: Gaming\Common\Bus\RoutingBus
-        public: false
         arguments:
-            -
-                'Gaming\Chat\Application\Query\MessagesQuery': ['@chat.chat-service', 'messages']
+            -   'Gaming\Chat\Application\Query\MessagesQuery': ['@chat.chat-service', 'messages']
+
+    chat.validating-query-bus:
+        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
+        decorates: 'chat.query-bus'
+        arguments: ['@.inner', '@validator']

--- a/config/chat/services/subscriber.yml
+++ b/config/chat/services/subscriber.yml
@@ -1,9 +1,5 @@
 services:
-
     chat.publish-stored-events-subscriber:
         class: Gaming\Chat\Infrastructure\Messaging\PublishDomainEventsToMessageBrokerSubscriber
-        public: false
-        arguments:
-            - '@gaming.message-broker.gaming-exchange-publisher'
-        tags:
-            - { name: 'chat.stored-event-subscriber', key: 'publish-to-message-broker' }
+        arguments: ['@gaming.message-broker.gaming-exchange-publisher']
+        tags: [{ name: 'chat.stored-event-subscriber', key: 'publish-to-message-broker' }]

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,26 +1,19 @@
 parameters:
-    # Workaround for doctrine/doctrine-migrations-bundle:^3.0
-    # To be able to use multiple connections, the bundle requires a default connection.
-    # See https://github.com/marein/php-gaming-website/issues/62.
+    # doctrine/doctrine-migrations-bundle requires a default connection.
     doctrine.migrations.preferred_connection: identity
 
-imports:
-    - { resource: chat/config.yml }
-    - { resource: connect-four/config.yml }
-    - { resource: identity/config.yml }
-    - { resource: web-interface/config.yml }
+imports: [{ resource: '*/config.yml' }]
 
 framework:
     secret: '%env(APP_KERNEL_SECRET)%'
     validation:
         enabled: true
     router:
-        resource: "%kernel.project_dir%/config/routing.yml"
+        resource: '%kernel.project_dir%/config/routing.yml'
     asset_mapper:
-        importmap_path: "%kernel.project_dir%/config/importmap.php"
+        importmap_path: '%kernel.project_dir%/config/importmap.php'
         importmap_polyfill: false # It's manually added to the base template (with feature detection).
-        paths:
-            - assets/
+        paths: [assets/]
 
 monolog:
     handlers:
@@ -35,47 +28,32 @@ twig:
     strict_variables: '%kernel.debug%'
 
 services:
-
-    gaming.schedule-doctrine-connection-heartbeat-middleware:
-        class: Gaming\Common\DoctrineHeartbeatMiddleware\SchedulePeriodicHeartbeatMiddleware
-        arguments:
-            - '@gaming.scheduler'
-            - 60
-            - '@clock'
-        tags:
-            - { name: doctrine.middleware }
+    Gaming\Common\DoctrineHeartbeatMiddleware\SchedulePeriodicHeartbeatMiddleware:
+        arguments: ['@gaming.scheduler', 60, '@clock']
+        tags: [{ name: doctrine.middleware }]
 
     gaming.message-broker.connection-factory:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\ConnectionFactory\AmqpStreamConnectionFactory
-        arguments:
-            - '%env(APP_RABBIT_MQ_DSN)%'
+        arguments: ['%env(APP_RABBIT_MQ_DSN)%']
 
     gaming.message-broker.declare-topology-connection-factory:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\ConnectionFactory\DeclareTopologyConnectionFactory
         decorates: gaming.message-broker.connection-factory
-        arguments:
-            - '@.inner'
-            - '@gaming.message-broker.topology'
+        arguments: ['@.inner', '@gaming.message-broker.topology']
 
     gaming.message-broker.schedule-periodic-heartbeat-connection-factory:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\ConnectionFactory\SchedulePeriodicHeartbeatConnectionFactory
         decorates: gaming.message-broker.connection-factory
-        arguments:
-            - '@.inner'
-            - '@gaming.scheduler'
+        arguments: ['@.inner', '@gaming.scheduler']
 
     gaming.message-broker.gaming-exchange-topology:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\Topology\ExchangeTopology
-        arguments:
-            - 'gaming'
-            - !php/const PhpAmqpLib\Exchange\AMQPExchangeType::TOPIC
-        tags:
-            - { name: 'gaming.message-broker.topology', priority: 100 }
+        arguments: ['gaming', !php/const PhpAmqpLib\Exchange\AMQPExchangeType::TOPIC]
+        tags: [{ name: 'gaming.message-broker.topology', priority: 100 }]
 
     gaming.message-broker.topology:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\Topology\CompositeTopology
-        arguments:
-            - !tagged { tag: 'gaming.message-broker.topology' }
+        arguments: [!tagged { tag: 'gaming.message-broker.topology' }]
 
     gaming.message-broker.message-translator:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\MessageTranslator\ConfigurableMessageTranslator
@@ -85,8 +63,7 @@ services:
 
     gaming.message-broker.message-router:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\MessageRouter\RouteMessagesToExchange
-        arguments:
-            - 'gaming'
+        arguments: ['gaming']
 
     gaming.message-broker.gaming-exchange-publisher:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\AmqpPublisher
@@ -105,40 +82,28 @@ services:
             - '@gaming.message-broker.message-router'
             - '@event_dispatcher'
 
-    gaming.consume-messages-command:
-        class: Gaming\Common\MessageBroker\Integration\Symfony\ConsumeMessagesCommand
-        arguments:
-            - !tagged_locator { tag: 'gaming.consumer', index_by: 'key' }
-        tags:
-            - { name: console.command, command: gaming:consume-messages, description: 'Consume messages.' }
+    Gaming\Common\MessageBroker\Integration\Symfony\ConsumeMessagesCommand:
+        arguments: [!tagged_locator { tag: 'gaming.consumer', index_by: 'key' }]
+        tags: [{ name: console.command, command: gaming:consume-messages, description: 'Consume messages.' }]
 
     Gaming\Common\MessageBroker\Integration\Symfony\ResetServicesListener:
-        arguments:
-            - '@services_resetter'
-            - 50
-        tags:
-            - { name: kernel.event_listener, method: 'messageHandled', priority: -50 }
+        arguments: ['@services_resetter', 50]
+        tags: [{ name: kernel.event_listener, method: 'messageHandled', priority: -50 }]
 
     Gaming\Common\MessageBroker\EventListener\ThrowWhenMessageReturned:
-        arguments:
-            - '@logger'
-        tags:
-            - { name: kernel.event_listener, method: 'messageReturned', priority: 50 }
+        arguments: ['@logger']
+        tags: [{ name: kernel.event_listener, method: 'messageReturned', priority: 50 }]
 
     Gaming\Common\MessageBroker\EventListener\ThrowWhenMessageFailed:
-        arguments:
-            - '@logger'
-        tags:
-            - { name: kernel.event_listener, method: 'messageFailed' }
+        arguments: ['@logger']
+        tags: [{ name: kernel.event_listener, method: 'messageFailed' }]
 
     Gaming\Common\EventStore\Integration\Symfony\ResetServicesListener:
-        arguments:
-            - '@services_resetter'
-            - 10
-        tags:
-            - { name: kernel.event_listener, method: 'eventsCommitted', priority: -50 }
+        arguments: ['@services_resetter', 10]
+        tags: [{ name: kernel.event_listener, method: 'eventsCommitted', priority: -50 }]
 
-    Gaming\Common\Bus\Integration\FormViolationMapper: ~
+    gaming.form-violation-mapper:
+        class: Gaming\Common\Bus\Integration\FormViolationMapper
 
     gaming.scheduler:
         class: Gaming\Common\Scheduler\PcntlScheduler
@@ -146,15 +111,10 @@ services:
     # Custom exception listener for the gaming domain.
     # Lower priority so that the profiler is respected.
     # todo: This can be removed as soon as https://github.com/marein/php-gaming-website/issues/34 is done.
-    gaming.exception-to-json-listener:
-        class: Gaming\Common\ExceptionHandling\GamingExceptionListener
-        tags:
-            - { name: kernel.event_listener, event: kernel.exception, priority: -100 }
+    Gaming\Common\ExceptionHandling\GamingExceptionListener:
+        tags: [{ name: kernel.event_listener, event: kernel.exception, priority: -100 }]
 
     # Lower priority so that the profiler is respected.
-    gaming.application-exception-to-json-listener:
-        class: Gaming\Common\Bus\Integration\ApplicationExceptionToJsonListener
-        arguments:
-            - []
-        tags:
-            - { name: kernel.event_listener, event: kernel.exception, priority: -99 }
+    Gaming\Common\Bus\Integration\ApplicationExceptionToJsonListener:
+        arguments: [[]]
+        tags: [{ name: kernel.event_listener, event: kernel.exception, priority: -99 }]

--- a/config/config_dev.yml
+++ b/config/config_dev.yml
@@ -1,11 +1,10 @@
-imports:
-    - { resource: config.yml }
+imports: [{ resource: config.yml }]
 
 framework:
     profiler:
         only_exceptions: false
     router:
-        resource: "%kernel.project_dir%/config/routing_dev.yml"
+        resource: '%kernel.project_dir%/config/routing_dev.yml'
 
 web_profiler:
     toolbar: true
@@ -19,13 +18,10 @@ monolog:
 services:
     Gaming\Common\EventStore\Integration\Doctrine\SkipDebugMatchingSqlPatternLogger:
         decorates: 'monolog.logger.doctrine'
-        arguments:
-            - '@.inner'
-            - ['/^SELECT.*FROM event_store .*WHERE.*id >/']
+        arguments: ['@.inner', ['/^SELECT.*FROM event_store .*WHERE.*id >/']]
 
     Gaming\Common\MessageBroker\EventListener\DebugEvents:
-        arguments:
-            - '@logger'
+        arguments: ['@logger']
         tags:
             - { name: kernel.event_listener, method: 'messageReceived' }
             - { name: kernel.event_listener, method: 'messageHandled' }
@@ -35,8 +31,7 @@ services:
             - { name: kernel.event_listener, method: 'requestSent' }
 
     Gaming\Common\EventStore\EventListener\DebugEvents:
-        arguments:
-            - '@logger'
+        arguments: ['@logger']
         tags:
             - { name: kernel.event_listener, method: 'eventsFetched' }
             - { name: kernel.event_listener, method: 'eventsCommitted' }

--- a/config/config_prod.yml
+++ b/config/config_prod.yml
@@ -1,2 +1,1 @@
-imports:
-    - { resource: config.yml }
+imports: [{ resource: config.yml }]

--- a/config/connect-four/config.yml
+++ b/config/connect-four/config.yml
@@ -1,5 +1,4 @@
-imports:
-    - { resource: services/ }
+imports: [{ resource: services/ }]
 
 doctrine:
     dbal:
@@ -9,5 +8,5 @@ doctrine:
                 server_version: '8.2'
                 charset: utf8mb4
                 default_table_options:
-                     charset: utf8mb4
-                     collate: utf8mb4_unicode_ci
+                    charset: utf8mb4
+                    collate: utf8mb4_unicode_ci

--- a/config/connect-four/services/command_bus.yml
+++ b/config/connect-four/services/command_bus.yml
@@ -1,66 +1,38 @@
 services:
-
-    # The following definitions decorate the routing command bus. This could be done with a factory object.
     connect-four.command-bus:
-        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
-        public: false
-        arguments:
-            - '@connect-four.retry-command-bus'
-            - '@validator'
+        class: Gaming\Common\Bus\Psr11RoutingBus
+        arguments: [!tagged_locator { tag: 'connect-four.command-bus.handler', index_by: 'key' }]
 
     connect-four.retry-command-bus:
         class: Gaming\Common\Bus\RetryBus
-        public: false
-        arguments:
-            - '@connect-four.routing-command-bus'
-            - 3
-            - 'Gaming\Common\Domain\Exception\ConcurrencyException'
+        decorates: 'connect-four.command-bus'
+        arguments: ['@.inner', 3,'Gaming\Common\Domain\Exception\ConcurrencyException']
 
-    # This is pretty ugly. We can use tags, or create this via a factory in php.
-    connect-four.routing-command-bus:
-        class: Gaming\Common\Bus\RoutingBus
-        public: false
-        arguments:
-            -
-                'Gaming\ConnectFour\Application\Game\Command\AbortCommand': '@connect-four.command.abort-handler'
-                'Gaming\ConnectFour\Application\Game\Command\ResignCommand': '@connect-four.command.resign-handler'
-                'Gaming\ConnectFour\Application\Game\Command\AssignChatCommand': '@connect-four.command.assign-chat-handler'
-                'Gaming\ConnectFour\Application\Game\Command\JoinCommand': '@connect-four.command.join-handler'
-                'Gaming\ConnectFour\Application\Game\Command\MoveCommand': '@connect-four.command.move-handler'
-                'Gaming\ConnectFour\Application\Game\Command\OpenCommand': '@connect-four.command.open-handler'
+    connect-four.validating-command-bus:
+        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
+        decorates: 'connect-four.command-bus'
+        arguments: ['@.inner', '@validator']
 
-    connect-four.command.abort-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\AbortHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\AbortHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\AbortCommand }]
 
-    connect-four.command.resign-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\ResignHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\ResignHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\ResignCommand }]
 
-    connect-four.command.assign-chat-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\AssignChatHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\AssignChatHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\AssignChatCommand }]
 
-    connect-four.command.join-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\JoinHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\JoinHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\JoinCommand }]
 
-    connect-four.command.move-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\MoveHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\MoveHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\MoveCommand }]
 
-    connect-four.command.open-handler:
-        class: Gaming\ConnectFour\Application\Game\Command\OpenHandler
-        public: false
-        arguments:
-            - '@connect-four.game-repository'
+    Gaming\ConnectFour\Application\Game\Command\OpenHandler:
+        arguments: ['@connect-four.game-repository']
+        tags: [{ name: connect-four.command-bus.handler, key: Gaming\ConnectFour\Application\Game\Command\OpenCommand }]

--- a/config/connect-four/services/console.yml
+++ b/config/connect-four/services/console.yml
@@ -1,15 +1,14 @@
 services:
-
     connect-four.follow-event-store-command:
         class: Gaming\Common\EventStore\Integration\Symfony\FollowEventStoreCommand
-        public: false
         arguments:
             - '@connect-four.event-store'
             - !service
                 class: Gaming\Common\EventStore\Integration\Predis\PredisEventStorePointerFactory
-                arguments:
-                    - '@connect-four.predis'
+                arguments: ['@connect-four.predis']
             - !tagged_locator { tag: 'connect-four.stored-event-subscriber', index_by: 'key' }
             - '@event_dispatcher'
         tags:
-            - { name: console.command, command: connect-four:follow-event-store, description: 'Publish events to subscribers.' }
+            -   name: console.command
+                command: connect-four:follow-event-store
+                description: 'Publish events to subscribers.'

--- a/config/connect-four/services/consumer.yml
+++ b/config/connect-four/services/consumer.yml
@@ -1,13 +1,8 @@
 services:
-
     connect-four.referee-message-handler.topology:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\Topology\QueueTopology
-        arguments:
-            - 'ConnectFour.Referee'
-            - 'gaming'
-            - ['ConnectFour.PlayerJoined']
-        tags:
-            - { name: 'gaming.message-broker.topology' }
+        arguments: ['ConnectFour.Referee', 'gaming', ['ConnectFour.PlayerJoined']]
+        tags: [{ name: 'gaming.message-broker.topology' }]
 
     connect-four.referee-message-handler.consumer:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\AmqpConsumer
@@ -15,11 +10,8 @@ services:
         arguments:
             - !service
                 class: Gaming\ConnectFour\Port\Adapter\Messaging\RefereeMessageHandler
-                arguments:
-                    - '@connect-four.command-bus'
+                arguments: ['@connect-four.command-bus']
             - !service
                 class: Gaming\Common\MessageBroker\Integration\AmqpLib\QueueConsumer\ConsumeQueues
-                arguments:
-                    - '@connect-four.referee-message-handler.topology'
-        tags:
-            - { name: 'gaming.consumer', key: 'connect-four.referee' }
+                arguments: ['@connect-four.referee-message-handler.topology']
+        tags: [{ name: 'gaming.consumer', key: 'connect-four.referee' }]

--- a/config/connect-four/services/game.yml
+++ b/config/connect-four/services/game.yml
@@ -1,15 +1,10 @@
 services:
-
     connect-four.game-controller:
         class: Gaming\ConnectFour\Port\Adapter\Http\GameController
-        public: false
-        arguments:
-            - '@connect-four.command-bus'
-            - '@connect-four.query-bus'
+        arguments: ['@connect-four.command-bus', '@connect-four.query-bus']
 
     connect-four.game-repository:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\DoctrineJsonGameRepository
-        public: false
         arguments:
             - '@connect-four.doctrine-dbal'
             - 'game'
@@ -17,35 +12,20 @@ services:
             - '@connect-four.normalizer'
             - !service
                 class: Gaming\Common\Sharding\Integration\Crc32ModShards
-                arguments:
-                    - '%env(csv:APP_CONNECT_FOUR_DOCTRINE_DBAL_SHARDS)%'
+                arguments: ['%env(csv:APP_CONNECT_FOUR_DOCTRINE_DBAL_SHARDS)%']
 
     connect-four.game-store:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\PredisGameStore
-        public: false
-        arguments:
-            - '@connect-four.predis'
-            - 'game:'
-            - '@connect-four.normalizer'
-            - '@connect-four.game-repository'
+        arguments: ['@connect-four.predis', 'game:', '@connect-four.normalizer', '@connect-four.game-repository']
 
     connect-four.games-by-player-store:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\PredisGamesByPlayerStore
-        public: false
-        arguments:
-            - '@connect-four.predis'
-            - 'games-by-player:'
+        arguments: ['@connect-four.predis', 'games-by-player:']
 
     connect-four.open-game-store:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\PredisOpenGameStore
-        public: false
-        arguments:
-            - '@connect-four.predis'
-            - 'open-games'
+        arguments: ['@connect-four.predis', 'open-games']
 
     connect-four.running-games-store:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Repository\PredisRunningGameStore
-        public: false
-        arguments:
-            - '@connect-four.predis'
-            - 'running-games'
+        arguments: ['@connect-four.predis', 'running-games']

--- a/config/connect-four/services/game_migrating_normalizer.yml
+++ b/config/connect-four/services/game_migrating_normalizer.yml
@@ -1,14 +1,9 @@
 services:
-
     connect-four.migrating-normalizer.game-migrations:
         class: Gaming\Common\Normalizer\Migrations
-        arguments:
-            - 'schemaVersion'
-            - !tagged_iterator connect-four.migrating-normalizer.game-migration
-        tags:
-            - { name: 'connect-four.migrating-normalizer.migrations', key: 'Gaming\ConnectFour\Domain\Game\Game' }
+        arguments: ['schemaVersion', !tagged_iterator connect-four.migrating-normalizer.game-migration]
+        tags: [{ name: 'connect-four.migrating-normalizer.migrations', key: 'Gaming\ConnectFour\Domain\Game\Game' }]
 
     connect-four.migrating-normalizer.game-migration.stone-as-scalar:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\MigratingNormalizer\StoneAsScalarMigration
-        tags:
-            - { name: 'connect-four.migrating-normalizer.game-migration' }
+        tags: [{ name: 'connect-four.migrating-normalizer.game-migration' }]

--- a/config/connect-four/services/normalizer.yml
+++ b/config/connect-four/services/normalizer.yml
@@ -1,5 +1,4 @@
 services:
-
     connect-four.jms:
         class: JMS\Serializer\Serializer
         factory: ['Gaming\Common\JmsSerializer\JmsSerializerFactory', 'create']
@@ -9,26 +8,20 @@ services:
             - { 'Gaming': '%kernel.project_dir%/src/ConnectFour/Port/Adapter/Persistence/Jms' }
             - !tagged_iterator connect-four.jms.subscriber
 
-    connect-four.jms.subscriber.game-id:
-        class: Gaming\ConnectFour\Port\Adapter\Persistence\Jms\GameIdSubscriber
+    Gaming\ConnectFour\Port\Adapter\Persistence\Jms\GameIdSubscriber:
         tags: ['connect-four.jms.subscriber']
 
-    connect-four.jms.subscriber.field:
-        class: Gaming\ConnectFour\Port\Adapter\Persistence\Jms\FieldSubscriber
+    Gaming\ConnectFour\Port\Adapter\Persistence\Jms\FieldSubscriber:
         tags: ['connect-four.jms.subscriber']
 
-    connect-four.jms.subscriber.stone:
-        class: Gaming\ConnectFour\Port\Adapter\Persistence\Jms\StoneSubscriber
+    Gaming\ConnectFour\Port\Adapter\Persistence\Jms\StoneSubscriber:
         tags: ['connect-four.jms.subscriber']
+
+    connect-four.normalizer:
+        class: Gaming\Common\Normalizer\Integration\JmsSerializerNormalizer
+        arguments: ['@connect-four.jms']
 
     connect-four.migrating-normalizer:
         class: Gaming\Common\Normalizer\MigratingNormalizer
         decorates: connect-four.normalizer
-        arguments:
-            - '@.inner'
-            - !tagged { tag: 'connect-four.migrating-normalizer.migrations', index_by: 'key' }
-
-    connect-four.normalizer:
-        class: Gaming\Common\Normalizer\Integration\JmsSerializerNormalizer
-        arguments:
-            - '@connect-four.jms'
+        arguments: ['@.inner', !tagged { tag: 'connect-four.migrating-normalizer.migrations', index_by: 'key' }]

--- a/config/connect-four/services/persistence.yml
+++ b/config/connect-four/services/persistence.yml
@@ -1,23 +1,16 @@
 services:
-
     connect-four.predis:
         class: Predis\Client
-        public: false
-        arguments:
-            - '%env(APP_CONNECT_FOUR_PREDIS_CLIENT_URL)%'
-            - { prefix: 'connect-four:' }
+        arguments: ['%env(APP_CONNECT_FOUR_PREDIS_CLIENT_URL)%', { prefix: 'connect-four:' }]
 
     connect-four.doctrine-dbal:
         alias: 'doctrine.dbal.connect_four_connection'
 
     connect-four.event-store:
         class: Gaming\Common\EventStore\Integration\Doctrine\DoctrineEventStore
-        public: false
         arguments:
             - '@connect-four.doctrine-dbal'
             - 'event_store'
             - !service
                 class: Gaming\Common\EventStore\Integration\JmsSerializer\JmsContentSerializer
-                arguments:
-                    - '@connect-four.jms'
-                    - 'Gaming\Common\Domain\DomainEvent'
+                arguments: ['@connect-four.jms', 'Gaming\Common\Domain\DomainEvent']

--- a/config/connect-four/services/query_bus.yml
+++ b/config/connect-four/services/query_bus.yml
@@ -1,43 +1,25 @@
 services:
-
-    # This is pretty ugly. We can use tags, or create this via a factory in php.
     connect-four.query-bus:
+        class: Gaming\Common\Bus\Psr11RoutingBus
+        arguments: [!tagged_locator { tag: 'connect-four.query-bus.handler', index_by: 'key' }]
+
+    connect-four.validating-query-bus:
         class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
-        public: false
-        arguments:
-            - '@connect-four.routing-query-bus'
-            - '@validator'
+        decorates: 'connect-four.query-bus'
+        arguments: ['@.inner', '@validator']
 
-    connect-four.routing-query-bus:
-        class: Gaming\Common\Bus\RoutingBus
-        public: false
-        arguments:
-            -
-                'Gaming\ConnectFour\Application\Game\Query\GameQuery': '@connect-four.query.game-handler'
-                'Gaming\ConnectFour\Application\Game\Query\GamesByPlayerQuery': '@connect-four.query.games-by-player-handler'
-                'Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery': '@connect-four.query.open-games-handler'
-                'Gaming\ConnectFour\Application\Game\Query\RunningGamesQuery': '@connect-four.query.running-games-handler'
+    Gaming\ConnectFour\Application\Game\Query\GameHandler:
+        arguments: ['@connect-four.game-store']
+        tags: [{ name: connect-four.query-bus.handler, key: Gaming\ConnectFour\Application\Game\Query\GameQuery }]
 
-    connect-four.query.game-handler:
-        class: Gaming\ConnectFour\Application\Game\Query\GameHandler
-        public: false
-        arguments:
-            - '@connect-four.game-store'
+    Gaming\ConnectFour\Application\Game\Query\GamesByPlayerHandler:
+        arguments: ['@connect-four.games-by-player-store']
+        tags: [{ name: connect-four.query-bus.handler, key: Gaming\ConnectFour\Application\Game\Query\GamesByPlayerQuery }]
 
-    connect-four.query.games-by-player-handler:
-        class: Gaming\ConnectFour\Application\Game\Query\GamesByPlayerHandler
-        public: false
-        arguments:
-            - '@connect-four.games-by-player-store'
+    Gaming\ConnectFour\Application\Game\Query\OpenGamesHandler:
+        arguments: ['@connect-four.open-game-store']
+        tags: [{ name: connect-four.query-bus.handler, key: Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery }]
 
-    connect-four.query.open-games-handler:
-        class: Gaming\ConnectFour\Application\Game\Query\OpenGamesHandler
-        public: false
-        arguments:
-            - '@connect-four.open-game-store'
-
-    connect-four.query.running-games-handler:
-        class: Gaming\ConnectFour\Application\Game\Query\RunningGamesHandler
-        public: false
-        arguments:
-            - '@connect-four.running-games-store'
+    Gaming\ConnectFour\Application\Game\Query\RunningGamesHandler:
+        arguments: ['@connect-four.running-games-store']
+        tags: [{ name: connect-four.query-bus.handler, key: Gaming\ConnectFour\Application\Game\Query\RunningGamesQuery }]

--- a/config/connect-four/services/subscriber.yml
+++ b/config/connect-four/services/subscriber.yml
@@ -1,42 +1,25 @@
 services:
-
     connect-four.game-projection:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Projection\GameProjection
-        public: false
-        arguments:
-            - '@connect-four.game-store'
-        tags:
-            - { name: 'connect-four.stored-event-subscriber', key: 'game-projection' }
+        arguments: ['@connect-four.game-store']
+        tags: [{ name: 'connect-four.stored-event-subscriber', key: 'game-projection' }]
 
     connect-four.open-games-projection:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Projection\OpenGamesProjection
-        public: false
-        arguments:
-            - '@connect-four.open-game-store'
-        tags:
-            - { name: 'connect-four.stored-event-subscriber', key: 'open-games-projection' }
+        arguments: ['@connect-four.open-game-store']
+        tags: [{ name: 'connect-four.stored-event-subscriber', key: 'open-games-projection' }]
 
     connect-four.running-games-projection:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Projection\RunningGamesProjection
-        public: false
-        arguments:
-            - '@connect-four.running-games-store'
-        tags:
-            - { name: 'connect-four.stored-event-subscriber', key: 'running-games-projection' }
+        arguments: ['@connect-four.running-games-store']
+        tags: [{ name: 'connect-four.stored-event-subscriber', key: 'running-games-projection' }]
 
     connect-four.games-by-player-projection:
         class: Gaming\ConnectFour\Port\Adapter\Persistence\Projection\GamesByPlayerProjection
-        public: false
-        arguments:
-            - '@connect-four.games-by-player-store'
-        tags:
-            - { name: 'connect-four.stored-event-subscriber', key: 'games-by-player-projection' }
+        arguments: ['@connect-four.games-by-player-store']
+        tags: [{ name: 'connect-four.stored-event-subscriber', key: 'games-by-player-projection' }]
 
     connect-four.publish-stored-events-subscriber:
         class: Gaming\ConnectFour\Port\Adapter\Messaging\PublishDomainEventsToMessageBrokerSubscriber
-        public: false
-        arguments:
-            - '@gaming.message-broker.gaming-exchange-publisher'
-            - '@connect-four.normalizer'
-        tags:
-            - { name: 'connect-four.stored-event-subscriber', key: 'publish-to-message-broker' }
+        arguments: ['@gaming.message-broker.gaming-exchange-publisher', '@connect-four.normalizer']
+        tags: [{ name: 'connect-four.stored-event-subscriber', key: 'publish-to-message-broker' }]

--- a/config/identity/config.yml
+++ b/config/identity/config.yml
@@ -1,11 +1,9 @@
-imports:
-    - { resource: services/ }
+imports: [{ resource: services/ }]
 
 framework:
     validation:
         mapping:
-            paths:
-                - "%kernel.project_dir%/src/Identity/Port/Adapter/Validation/"
+            paths: ['%kernel.project_dir%/src/Identity/Port/Adapter/Validation/']
 
 doctrine:
     dbal:
@@ -15,14 +13,14 @@ doctrine:
                 server_version: '8.2'
                 charset: utf8mb4
                 default_table_options:
-                     charset: utf8mb4
-                     collate: utf8mb4_unicode_ci
+                    charset: utf8mb4
+                    collate: utf8mb4_unicode_ci
     orm:
         entity_managers:
             identity:
                 connection: identity
                 mappings:
                     user:
-                        type:     xml
-                        dir:      '%kernel.project_dir%/src/Identity/Port/Adapter/Persistence/Mapping/User'
-                        prefix:   Gaming\Identity\Domain\Model\User
+                        type: xml
+                        dir: '%kernel.project_dir%/src/Identity/Port/Adapter/Persistence/Mapping/User'
+                        prefix: Gaming\Identity\Domain\Model\User

--- a/config/identity/services/command_bus.yml
+++ b/config/identity/services/command_bus.yml
@@ -1,33 +1,21 @@
 services:
-
-    # The following definitions decorate the routing command bus. This could be done with a factory object.
     identity.command-bus:
-        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
-        public: false
+        class: Gaming\Common\Bus\RoutingBus
         arguments:
-            - '@identity.retry-command-bus'
-            - '@validator'
+            -   'Gaming\Identity\Application\User\Command\ArriveCommand': ['@identity.user-service', 'arrive']
+                'Gaming\Identity\Application\User\Command\SignUpCommand': ['@identity.user-service', 'signUp']
+
+    identity.transactional-command-bus:
+        class: Gaming\Common\Bus\Integration\DoctrineTransactionalBus
+        decorates: 'identity.command-bus'
+        arguments: ['@.inner', '@identity.doctrine-dbal']
 
     identity.retry-command-bus:
         class: Gaming\Common\Bus\RetryBus
-        public: false
-        arguments:
-            - '@identity.doctrine-transactional-command-bus'
-            - 3
-            - 'Gaming\Common\Domain\Exception\ConcurrencyException'
+        decorates: 'identity.command-bus'
+        arguments: ['@.inner', 3, 'Gaming\Common\Domain\Exception\ConcurrencyException']
 
-    identity.doctrine-transactional-command-bus:
-        class: Gaming\Common\Bus\Integration\DoctrineTransactionalBus
-        public: false
-        arguments:
-            - '@identity.routing-command-bus'
-            - '@identity.doctrine-dbal'
-
-    # This is pretty ugly. We can use tags, or create this via a factory in php.
-    identity.routing-command-bus:
-        class: Gaming\Common\Bus\RoutingBus
-        public: false
-        arguments:
-            -
-                'Gaming\Identity\Application\User\Command\ArriveCommand': ['@identity.user-service', 'arrive']
-                'Gaming\Identity\Application\User\Command\SignUpCommand': ['@identity.user-service', 'signUp']
+    identity.validating-command-bus:
+        class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
+        decorates: 'identity.command-bus'
+        arguments: ['@.inner', '@validator']

--- a/config/identity/services/console.yml
+++ b/config/identity/services/console.yml
@@ -1,16 +1,14 @@
 services:
-
     identity.follow-event-store-command:
         class: Gaming\Common\EventStore\Integration\Symfony\FollowEventStoreCommand
-        public: false
         arguments:
             - '@identity.event-store'
             - !service
                 class: Gaming\Common\EventStore\Integration\Doctrine\DoctrineMysqlEventStorePointerFactory
-                arguments:
-                    - '@identity.doctrine-dbal'
-                    - 'event_store_pointer'
+                arguments: ['@identity.doctrine-dbal', 'event_store_pointer']
             - !tagged_locator { tag: 'identity.stored-event-subscriber', index_by: 'key' }
             - '@event_dispatcher'
         tags:
-            - { name: console.command, command: identity:follow-event-store, description: 'Publish events to subscribers.' }
+            -   name: console.command
+                command: identity:follow-event-store
+                description: 'Publish events to subscribers.'

--- a/config/identity/services/normalizer.yml
+++ b/config/identity/services/normalizer.yml
@@ -1,5 +1,4 @@
 services:
-
     identity.jms:
         class: JMS\Serializer\Serializer
         factory: ['Gaming\Common\JmsSerializer\JmsSerializerFactory', 'create']
@@ -11,5 +10,4 @@ services:
 
     identity.normalizer:
         class: Gaming\Common\Normalizer\Integration\JmsSerializerNormalizer
-        arguments:
-            - '@identity.jms'
+        arguments: ['@identity.jms']

--- a/config/identity/services/persistence.yml
+++ b/config/identity/services/persistence.yml
@@ -1,5 +1,4 @@
 services:
-
     identity.doctrine-dbal:
         alias: 'doctrine.dbal.identity_connection'
 
@@ -8,20 +7,16 @@ services:
 
     identity.event-store:
         class: Gaming\Common\EventStore\Integration\Doctrine\DoctrineEventStore
-        public: false
         arguments:
             - '@identity.doctrine-dbal'
             - 'event_store'
             - !service
                 class: Gaming\Common\EventStore\Integration\JmsSerializer\JmsContentSerializer
-                arguments:
-                    - '@identity.jms'
-                    - 'Gaming\Common\Domain\DomainEvent'
+                arguments: ['@identity.jms', 'Gaming\Common\Domain\DomainEvent']
 
     identity.orm.publish-domain-events-listener:
         class: Gaming\Common\EventStore\Integration\Doctrine\EventListener\AppendDomainEvents
-        arguments:
-            - '@identity.event-store'
+        arguments: ['@identity.event-store']
         tags:
             - { name: doctrine.event_listener, event: postPersist, entity_manager: identity }
             - { name: doctrine.event_listener, event: postUpdate, entity_manager: identity }

--- a/config/identity/services/query_bus.yml
+++ b/config/identity/services/query_bus.yml
@@ -1,13 +1,11 @@
 services:
-
     identity.query-bus:
         class: Gaming\Common\Bus\RoutingBus
         arguments:
-            -
-                'Gaming\Identity\Application\User\Query\UserQuery': [ '@identity.user-service', 'user' ]
-                'Gaming\Identity\Application\User\Query\UserByEmailQuery': [ '@identity.user-service', 'userByEmail' ]
+            -   'Gaming\Identity\Application\User\Query\UserQuery': ['@identity.user-service', 'user']
+                'Gaming\Identity\Application\User\Query\UserByEmailQuery': ['@identity.user-service', 'userByEmail']
 
-    identity.symfony-validator-query-bus:
+    identity.validating-query-bus:
         class: Gaming\Common\Bus\Integration\SymfonyValidatorBus
         decorates: identity.query-bus
-        arguments: [ '@.inner', '@validator' ]
+        arguments: ['@.inner', '@validator']

--- a/config/identity/services/subscriber.yml
+++ b/config/identity/services/subscriber.yml
@@ -1,9 +1,5 @@
 services:
-
     identity.publish-stored-events-subscriber:
         class: Gaming\Identity\Port\Adapter\Messaging\PublishDomainEventsToMessageBrokerSubscriber
-        public: false
-        arguments:
-            - '@gaming.message-broker.gaming-exchange-publisher'
-        tags:
-            - { name: 'identity.stored-event-subscriber', key: 'publish-to-message-broker' }
+        arguments: ['@gaming.message-broker.gaming-exchange-publisher']
+        tags: [{ name: 'identity.stored-event-subscriber', key: 'publish-to-message-broker' }]

--- a/config/identity/services/user.yml
+++ b/config/identity/services/user.yml
@@ -1,19 +1,12 @@
 services:
-
     identity.user-controller:
         class: Gaming\Identity\Port\Adapter\Http\UserController
-        public: false
-        arguments:
-            - '@identity.command-bus'
+        arguments: ['@identity.command-bus']
 
     identity.user-repository:
         class: Gaming\Identity\Port\Adapter\Persistence\Repository\DoctrineUserRepository
-        public: false
-        arguments:
-            - '@identity.doctrine-orm'
+        arguments: ['@identity.doctrine-orm']
 
     identity.user-service:
         class: Gaming\Identity\Application\User\UserService
-        public: false
-        arguments:
-            - '@identity.user-repository'
+        arguments: ['@identity.user-repository']

--- a/config/routing.yml
+++ b/config/routing.yml
@@ -1,2 +1,1 @@
-WebInterface:
-    resource: web-interface/routing.yml
+Contexts: { resource: '*/routing.yml' }

--- a/config/routing_dev.yml
+++ b/config/routing_dev.yml
@@ -1,10 +1,10 @@
 _wdt:
-    resource: "@WebProfilerBundle/Resources/config/routing/wdt.xml"
-    prefix:   /_wdt
+    resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+    prefix: /_wdt
 
 _profiler:
-    resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
-    prefix:   /_profiler
+    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+    prefix: /_profiler
 
 _main:
     resource: routing.yml

--- a/config/web-interface/config.yml
+++ b/config/web-interface/config.yml
@@ -1,8 +1,5 @@
-imports:
-    - { resource: services/ }
+imports: [{ resource: services/ }]
 
-# The framework configuration belongs here, because when we transition to the microservice approach,
-# the other contexts don't have the concept of a session.
 framework:
     session:
         handler_id: web-interface.session-handler
@@ -11,9 +8,8 @@ framework:
         csrf_protection: false # CSRF protection is handled by marein/symfony-standard-headers-csrf-bundle.
 
 twig:
-    form_themes: [ 'bootstrap_5_layout.html.twig' ]
-    paths:
-        "%kernel.project_dir%/src/WebInterface/Presentation/Http/View": web-interface
+    form_themes: ['bootstrap_5_layout.html.twig']
+    paths: { '%kernel.project_dir%/src/WebInterface/Presentation/Http/View': web-interface }
 
 security:
     providers:
@@ -27,7 +23,7 @@ security:
             pattern: ^/
             login_link:
                 check_route: login_check
-                signature_properties: [ 'userIdentifier' ]
+                signature_properties: ['userIdentifier']
             custom_authenticators:
                 - 'web-interface.security.arrival_authenticator'
             logout:

--- a/config/web-interface/routing.yml
+++ b/config/web-interface/routing.yml
@@ -8,48 +8,42 @@ _symfony_logout:
 
 lobby:
     path: /
-    methods:
-        - GET
-    defaults:
-        _controller: web-interface.page-controller::lobbyAction
+    methods: [GET]
+    controller: web-interface.page-controller::lobbyAction
 
 profile:
     path: /profile
-    methods:
-        - GET
-    defaults:
-        _controller: web-interface.page-controller::profileAction
+    methods: [GET]
+    controller: web-interface.page-controller::profileAction
 
 game:
     path: /game/{id}
-    methods:
-        - GET
-    defaults:
-        _controller: web-interface.page-controller::gameAction
+    methods: [GET]
+    controller: web-interface.page-controller::gameAction
 
 signup:
     path: /signup
-    methods: [ GET, POST ]
+    methods: [GET, POST]
     controller: web-interface.signup-controller::indexAction
 
 signup_verify_email:
     path: /signup/verify-email
-    methods: [ GET ]
+    methods: [GET]
     controller: web-interface.signup-controller::verifyEmailAction
 
 signup_confirm:
     path: /signup/confirm
-    methods: [ GET, POST ]
+    methods: [GET, POST]
     controller: web-interface.signup-controller::confirmAction
 
 login:
     path: /login
-    methods: [ GET, POST ]
+    methods: [GET, POST]
     controller: web-interface.login-controller::indexAction
 
 login_check_inbox:
     path: /login/check-inbox
-    methods: [ GET ]
+    methods: [GET]
     controller: web-interface.login-controller::checkInboxAction
 
 login_check:
@@ -61,19 +55,15 @@ login_check:
 
 write_message:
     path: /api/chat/chats/{chatId}/write-message
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.chat-controller::writeMessageAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.chat-controller::writeMessageAction
+    defaults: { _format: json }
 
 messages:
     path: /api/chat/chats/{chatId}/messages
-    methods:
-        - GET
-    defaults:
-        _controller: web-interface.chat-controller::messagesAction
-        _format: json
+    methods: [GET]
+    controller: web-interface.chat-controller::messagesAction
+    defaults: { _format: json }
 
 ###############################################
 #             Connect Four Service            #
@@ -81,48 +71,36 @@ messages:
 
 open:
     path: /api/connect-four/games/open
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.connect-four-controller::openAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.connect-four-controller::openAction
+    defaults: { _format: json }
 
 abort:
     path: /api/connect-four/games/{gameId}/abort
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.connect-four-controller::abortAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.connect-four-controller::abortAction
+    defaults: { _format: json }
 
 resign:
     path: /api/connect-four/games/{gameId}/resign
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.connect-four-controller::resignAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.connect-four-controller::resignAction
+    defaults: { _format: json }
 
 join:
     path: /api/connect-four/games/{gameId}/join
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.connect-four-controller::joinAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.connect-four-controller::joinAction
+    defaults: { _format: json }
 
 move:
     path: /api/connect-four/games/{gameId}/move
-    methods:
-        - POST
-    defaults:
-        _controller: web-interface.connect-four-controller::moveAction
-        _format: json
+    methods: [POST]
+    controller: web-interface.connect-four-controller::moveAction
+    defaults: { _format: json }
 
 game_json:
     path: /api/connect-four/games/{gameId}
-    methods:
-        - GET
-    defaults:
-        _controller: web-interface.connect-four-controller::showAction
-        _format: json
+    methods: [GET]
+    controller: web-interface.connect-four-controller::showAction
+    defaults: { _format: json }

--- a/config/web-interface/services/console.yml
+++ b/config/web-interface/services/console.yml
@@ -1,14 +1,7 @@
 services:
-
-    web-interface.publish-running-games-count-to-nchan-command:
-        class: Gaming\WebInterface\Presentation\Console\PublishRunningGamesCountToNchanCommand
-        public: false
-        arguments:
-            - '@web-interface.connect-four-service'
-            - '@web-interface.browser-notifier'
+    Gaming\WebInterface\Presentation\Console\PublishRunningGamesCountToNchanCommand:
+        arguments: ['@web-interface.connect-four-service', '@web-interface.browser-notifier']
         tags:
-            - {
-                name: console.command,
-                command: web-interface:publish-running-games-count-to-nchan,
+            -   name: console.command
+                command: web-interface:publish-running-games-count-to-nchan
                 description: 'Publish number of running games to the browser.'
-            }

--- a/config/web-interface/services/consumer.yml
+++ b/config/web-interface/services/consumer.yml
@@ -1,5 +1,4 @@
 services:
-
     web-interface.publish-to-browser-message-handler.topology:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\Topology\HashExchangeTopology
         arguments:
@@ -8,8 +7,7 @@ services:
             - ['ConnectFour.#', 'Chat.MessageWritten']
             - '%env(APP_WEB_INTERFACE_PUBLISH_TO_BROWSER_SHARDS)%'
             - 'hash-on'
-        tags:
-            - { name: 'gaming.message-broker.topology' }
+        tags: [{ name: 'gaming.message-broker.topology' }]
 
     web-interface.publish-to-browser-message-handler.consumer:
         class: Gaming\Common\MessageBroker\Integration\AmqpLib\AmqpConsumer
@@ -17,13 +15,11 @@ services:
         arguments:
             - !service
                 class: Gaming\WebInterface\Infrastructure\Messaging\PublishMessageBrokerEventsToBrowserMessageHandler
-                arguments:
-                    - '@web-interface.browser-notifier'
+                arguments: ['@web-interface.browser-notifier']
             - !service
                 class: Gaming\Common\MessageBroker\Integration\AmqpLib\QueueConsumer\ConsumeQueueWithLeastConsumers
                 arguments:
                     - '@web-interface.publish-to-browser-message-handler.topology'
                     - '@web-interface.lock-factory'
                     - 'web-interface.publish-to-browser-message-handler.consumer'
-        tags:
-            - { name: 'gaming.consumer', key: 'web-interface.publish-to-browser' }
+        tags: [{ name: 'gaming.consumer', key: 'web-interface.publish-to-browser' }]

--- a/config/web-interface/services/controller.yml
+++ b/config/web-interface/services/controller.yml
@@ -1,13 +1,8 @@
 services:
-
     web-interface.page-controller:
         class: Gaming\WebInterface\Presentation\Http\PageController
-        arguments:
-            - '@twig'
-            - '@web-interface.connect-four-service'
-            - '@web-interface.security'
-        tags:
-            - 'controller.service_arguments'
+        arguments: ['@twig', '@web-interface.connect-four-service', '@web-interface.security']
+        tags: ['controller.service_arguments']
 
     web-interface.signup-controller:
         class: Gaming\WebInterface\Presentation\Http\SignupController
@@ -15,11 +10,9 @@ services:
             - '@uri_signer'
             - '@web-interface.security'
             - '@web-interface.identity-service'
-            - '@Gaming\Common\Bus\Integration\FormViolationMapper'
-        calls: [ [ setContainer, [ '@Psr\Container\ContainerInterface' ] ] ]
-        tags:
-            - 'controller.service_arguments'
-            - 'container.service_subscriber'
+            - '@gaming.form-violation-mapper'
+        calls: [[setContainer, ['@Psr\Container\ContainerInterface']]]
+        tags: ['controller.service_arguments', 'container.service_subscriber']
 
     web-interface.login-controller:
         class: Gaming\WebInterface\Presentation\Http\LoginController
@@ -29,24 +22,16 @@ services:
             - '@security.authenticator.firewall_aware_login_link_handler'
             - '@uri_signer'
             - '@identity.query-bus'
-            - '@Gaming\Common\Bus\Integration\FormViolationMapper'
-        calls: [ [ setContainer, [ '@Psr\Container\ContainerInterface' ] ] ]
-        tags:
-            - 'controller.service_arguments'
-            - 'container.service_subscriber'
+            - '@gaming.form-violation-mapper'
+        calls: [[setContainer, ['@Psr\Container\ContainerInterface']]]
+        tags: ['controller.service_arguments', 'container.service_subscriber']
 
     web-interface.chat-controller:
         class: Gaming\WebInterface\Presentation\Http\ChatController
-        arguments:
-            - '@web-interface.chat-service'
-            - '@web-interface.security'
-        tags:
-            - 'controller.service_arguments'
+        arguments: ['@web-interface.chat-service', '@web-interface.security']
+        tags: ['controller.service_arguments']
 
     web-interface.connect-four-controller:
         class: Gaming\WebInterface\Presentation\Http\ConnectFourController
-        arguments:
-            - '@web-interface.connect-four-service'
-            - '@web-interface.security'
-        tags:
-            - 'controller.service_arguments'
+        arguments: ['@web-interface.connect-four-service', '@web-interface.security']
+        tags: ['controller.service_arguments']

--- a/config/web-interface/services/integration.yml
+++ b/config/web-interface/services/integration.yml
@@ -1,22 +1,15 @@
 services:
-
     web-interface.chat-service:
         class: Gaming\WebInterface\Infrastructure\Integration\DirectControllerInvocationChatService
-        public: false
-        arguments:
-            - '@chat.chat-controller'
+        arguments: ['@chat.chat-controller']
 
     web-interface.connect-four-service:
         class: Gaming\WebInterface\Infrastructure\Integration\DirectControllerInvocationConnectFourService
-        public: false
-        arguments:
-            - '@connect-four.game-controller'
+        arguments: ['@connect-four.game-controller']
 
     web-interface.identity-service:
         class: Gaming\WebInterface\Infrastructure\Integration\DirectControllerInvocationIdentityService
-        public: false
-        arguments:
-            - '@identity.user-controller'
+        arguments: ['@identity.user-controller']
 
     web-interface.nchan:
         class: Marein\Nchan\Nchan
@@ -24,13 +17,8 @@ services:
             - '%env(APP_WEB_INTERFACE_NCHAN_BASE_URL)%'
             - !service
                 class: Marein\Nchan\HttpAdapter\Psr18ClientAdapter
-                arguments:
-                    - '@psr18.http_client'
-                    - '@psr18.http_client'
-                    - '@psr18.http_client'
+                arguments: ['@psr18.http_client', '@psr18.http_client', '@psr18.http_client']
 
     web-interface.browser-notifier:
         class: Gaming\WebInterface\Infrastructure\NchanBrowserNotifier
-        public: false
-        arguments:
-            - '@web-interface.nchan'
+        arguments: ['@web-interface.nchan']

--- a/config/web-interface/services/lock.yml
+++ b/config/web-interface/services/lock.yml
@@ -1,9 +1,7 @@
 services:
-
     web-interface.lock-factory:
         class: Symfony\Component\Lock\LockFactory
         arguments:
             - !service
                 class: Symfony\Component\Lock\Store\RedisStore
-                arguments:
-                    - '@web-interface.predis'
+                arguments: ['@web-interface.predis']

--- a/config/web-interface/services/persistence.yml
+++ b/config/web-interface/services/persistence.yml
@@ -1,15 +1,8 @@
 services:
-
     web-interface.predis:
         class: Predis\Client
-        public: false
-        arguments:
-            - '%env(APP_WEB_INTERFACE_PREDIS_CLIENT_URL)%'
-            - { prefix: 'web-interface:' }
+        arguments: ['%env(APP_WEB_INTERFACE_PREDIS_CLIENT_URL)%', { prefix: 'web-interface:' }]
 
     web-interface.session-handler:
         class: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
-        public: false
-        arguments:
-            - '@web-interface.predis'
-            - { prefix: 'session:', ttl: 86400 }
+        arguments: ['@web-interface.predis', { prefix: 'session:', ttl: 86400 }]

--- a/config/web-interface/services/security.yml
+++ b/config/web-interface/services/security.yml
@@ -1,18 +1,12 @@
 services:
+    web-interface.security:
+        class: Gaming\WebInterface\Infrastructure\Security\Security
+        arguments: ['@security.helper']
 
-  web-interface.security:
-    class: Gaming\WebInterface\Infrastructure\Security\Security
-    arguments:
-      - '@security.helper'
+    web-interface.security.user_provider:
+        class: Gaming\WebInterface\Infrastructure\Security\UserProvider
+        arguments: ['@identity.query-bus', '@clock']
 
-  web-interface.security.user_provider:
-    class: Gaming\WebInterface\Infrastructure\Security\UserProvider
-    arguments:
-      - '@identity.query-bus'
-      - '@clock'
-
-  web-interface.security.arrival_authenticator:
-    class: Gaming\WebInterface\Infrastructure\Security\ArrivalAuthenticator
-    arguments:
-      - '@web-interface.identity-service'
-      - '@security.token_storage'
+    web-interface.security.arrival_authenticator:
+        class: Gaming\WebInterface\Infrastructure\Security\ArrivalAuthenticator
+        arguments: ['@web-interface.identity-service', '@security.token_storage']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,13 @@ version: '3.4'
 
 x-php-container-volumes:
     &php-container-volumes
-        volumes:
-            - ./:/project:delegated
-            - php-vendor:/project/vendor
-            - asset-vendor:/project/assets/vendor
-            - proxysql.sock:/var/run/proxysql
-            - type: tmpfs
-              target: /project/var
+    volumes:
+        - ./:/project:delegated
+        - php-vendor:/project/vendor
+        - asset-vendor:/project/assets/vendor
+        - proxysql.sock:/var/run/proxysql
+        -   type: tmpfs
+            target: /project/var
 
 x-php-container:
     &php-container

--- a/src/Common/Bus/Psr11RoutingBus.php
+++ b/src/Common/Bus/Psr11RoutingBus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\Common\Bus;
+
+use Gaming\Common\Bus\Exception\BusException;
+use Psr\Container\ContainerInterface;
+
+final class Psr11RoutingBus implements Bus
+{
+    public function __construct(
+        private readonly ContainerInterface $container
+    ) {
+    }
+
+    public function handle(Request $request): mixed
+    {
+        return $this->container->has($request::class)
+            ? $this->container->get($request::class)($request)
+            : throw BusException::missingHandler($request::class);
+    }
+}

--- a/src/Common/DoctrineHeartbeatMiddleware/TrackActivityConnection.php
+++ b/src/Common/DoctrineHeartbeatMiddleware/TrackActivityConnection.php
@@ -8,7 +8,6 @@ use Closure;
 use Doctrine\DBAL\Driver\Connection;
 use Doctrine\DBAL\Driver\Result;
 use Doctrine\DBAL\Driver\Statement;
-use Doctrine\DBAL\ParameterType;
 
 final class TrackActivityConnection implements Connection
 {

--- a/src/WebInterface/Presentation/Http/Form/LoginType.php
+++ b/src/WebInterface/Presentation/Http/Form/LoginType.php
@@ -12,9 +12,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class LoginType extends AbstractType
 {
-    /**
-     * @param array{confirm: bool} $options
-     */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder


### PR DESCRIPTION
The service container definitions are 8 years old. New features have also been added in the meantime. The following changes have been made:
* Remove public set to false as this is the default.
* Import directories instead of picking files.
* All files follow the same format.
* Use tagged locators for command and query bus.
* Use class name as service id if it's not referenced.
* Use decorate where appropriate.
* Use single quotes instead of double quotes.

To obtain clear dependency graphs, autowiring is still not used intentionally.

Additionally reformat other yaml files in the project.