### PR TITLE
Use symfony/runtime

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@
 #          Shared          #
 ############################
 # dev|prod
-APP_ENVIRONMENT='dev'
+APP_ENV='dev'
 APP_KERNEL_SECRET='ThisTokenIsNotSoSecretChangeIt'
 APP_WAIT_FOR='unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbitmq:5672,nchan:81'
 APP_RUN_MIGRATIONS='1'

--- a/bin/console
+++ b/bin/console
@@ -1,32 +1,16 @@
 #!/usr/bin/env php
 <?php
+
 declare(strict_types=1);
 
 namespace {
 
     use Gaming\Kernel;
     use Symfony\Bundle\FrameworkBundle\Console\Application;
-    use Symfony\Component\Console\Input\ArgvInput;
-    use Symfony\Component\ErrorHandler\Debug;
 
-    umask(0000);
+    require_once __DIR__ . '/../vendor/autoload_runtime.php';
 
-    set_time_limit(0);
-
-    require_once __DIR__ . '/../vendor/autoload.php';
-
-    $input = new ArgvInput();
-    $environment = $input->getParameterOption(
-            ['--env', '-e'],
-            $_SERVER['APP_ENVIRONMENT'] ?? $_ENV['APP_ENVIRONMENT'] ?? 'dev'
-    );
-    $isDevelopmentEnvironment = $environment !== 'prod';
-
-    if ($isDevelopmentEnvironment) {
-        Debug::enable();
-    }
-
-    $kernel = new Kernel($environment, $isDevelopmentEnvironment);
-    $application = new Application($kernel);
-    $application->run($input);
+    return static function (array $context): Application {
+        return new Application(new Kernel($context['APP_ENV'], (bool)$context['APP_DEBUG']));
+    };
 }

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
     "symfony/http-kernel": "^7.0",
     "symfony/lock": "^7.0",
     "symfony/monolog-bundle": "^3.8",
+    "symfony/runtime": "^7.1",
     "symfony/security-bundle": "^7.0",
     "symfony/service-contracts": "^3.3",
     "symfony/translation-contracts": "^3.5",
@@ -86,7 +87,8 @@
     "sort-packages": true,
     "allow-plugins": {
       "composer/package-versions-deprecated": true,
-      "phpstan/extension-installer": true
+      "phpstan/extension-installer": true,
+      "symfony/runtime": true
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4a053d776fc94f8a9f5410b58a6366d",
+    "content-hash": "c555b56669637c19f903671c534332a4",
     "packages": [
         {
             "name": "composer/semver",
@@ -5706,6 +5706,85 @@
                 }
             ],
             "time": "2024-05-31T14:57:53+00:00"
+        },
+        {
+            "name": "symfony/runtime",
+            "version": "v7.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/runtime.git",
+                "reference": "ea34522c447dd91a2b31cb330ee4540a56ba53f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/ea34522c447dd91a2b31cb330ee4540a56ba53f6",
+                "reference": "ea34522c447dd91a2b31cb330ee4540a56ba53f6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/dotenv": "<6.4"
+            },
+            "require-dev": {
+                "composer/composer": "^2.6",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dotenv": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Component\\Runtime\\Internal\\ComposerPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Runtime\\": "",
+                    "Symfony\\Runtime\\Symfony\\Component\\": "Internal/"
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Enables decoupling PHP applications from global state",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "runtime"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/runtime/tree/v7.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T14:55:39+00:00"
         },
         {
             "name": "symfony/security-bundle",

--- a/deploy/load-test/stack/app.env
+++ b/deploy/load-test/stack/app.env
@@ -1,4 +1,4 @@
-APP_ENVIRONMENT=prod
+APP_ENV=prod
 APP_KERNEL_SECRET=ThisTokenIsNotSoSecretChangeIt
 APP_WAIT_FOR=unix:///var/run/proxysql/proxysql.sock,chat-mysql:3306,connect-four-mysql-1:3306,connect-four-mysql-2:3306,connect-four-mysql-3:3306,connect-four-mysql-4:3306,connect-four-mysql-5:3306,identity-mysql:3306,chat-redis:6379,connect-four-redis:6379,web-interface-redis:6379,rabbitmq:5672,nchan:81
 APP_RUN_MIGRATIONS=1

--- a/deploy/single-server/docker-compose.yml
+++ b/deploy/single-server/docker-compose.yml
@@ -6,7 +6,7 @@ x-php-container:
     &php-container
     image: marein/php-gaming-website:php-fpm
     environment:
-        APP_ENVIRONMENT: "prod"
+        APP_ENV: "prod"
         APP_KERNEL_SECRET: "ThisTokenIsNotSoSecretChangeIt"
         APP_WAIT_FOR: "unix:///var/run/proxysql/proxysql.sock,mysql:3306,redis:6379,rabbitmq:5672,nchan:81"
         APP_RUN_MIGRATIONS: "1"

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -5,7 +5,7 @@ x-php-container:
     image: marein/php-gaming-website:php-fpm
     env_file: ./.env
     environment:
-        APP_ENVIRONMENT: prod
+        APP_ENV: prod
     depends_on:
         - mysql
         - proxysql

--- a/docker/warmup.sh
+++ b/docker/warmup.sh
@@ -15,3 +15,5 @@ else
     bin/console importmap:install --env=prod
     bin/console asset-map:compile --env=prod
 fi
+
+chown -R www-data:www-data var

--- a/project
+++ b/project
@@ -104,7 +104,10 @@ acceptance() {
 }
 
 buildProductionImages() {
-    docker build --build-arg environment=production --file docker/Dockerfile --tag marein/php-gaming-website:php-fpm .
+    docker build --pull \
+        --build-arg environment=production \
+        --file docker/Dockerfile \
+        --tag marein/php-gaming-website:php-fpm .
 }
 
 pushProductionImages() {

--- a/public/index.php
+++ b/public/index.php
@@ -1,24 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace {
 
     use Gaming\Kernel;
-    use Symfony\Component\ErrorHandler\Debug;
-    use Symfony\Component\HttpFoundation\Request;
 
-    require_once __DIR__ . '/../vendor/autoload.php';
+    require_once __DIR__ . '/../vendor/autoload_runtime.php';
 
-    $environment = $_SERVER['APP_ENVIRONMENT'] ?? $_ENV['APP_ENVIRONMENT'] ?? 'dev';
-    $isDevelopmentEnvironment = $environment !== 'prod';
-
-    if ($isDevelopmentEnvironment) {
-        Debug::enable();
-    }
-
-    $kernel = new Kernel($environment, $isDevelopmentEnvironment);
-    $request = Request::createFromGlobals();
-    $response = $kernel->handle($request);
-    $response->send();
-    $kernel->terminate($request, $response);
+    return static function (array $context): Kernel {
+        return new Kernel($context['APP_ENV'], (bool)$context['APP_DEBUG']);
+    };
 }


### PR DESCRIPTION
Standardize the bootstrapping of the application. Additionally:
* Rename APP_ENVIRONMENT to APP_ENV to comply with Symfony's standard.
* Set file permissions to remove umask(0000).
* Pull latest image before building production images.

Second attempt for #247. `setfacl` during `docker build` isn't applied consistently in all environments. This needs to be fixed.