### PR TITLE
Move open games UI to ConnectFour

### DIFF
--- a/src/ConnectFour/Port/Adapter/Http/FragmentController.php
+++ b/src/ConnectFour/Port/Adapter/Http/FragmentController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Gaming\ConnectFour\Port\Adapter\Http;
 
 use Gaming\Common\Bus\Bus;
+use Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery;
 use Gaming\ConnectFour\Application\Game\Query\RunningGamesQuery;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,13 @@ final class FragmentController extends AbstractController
     {
         return $this->render('@connect-four/statistics.html.twig', [
             'runningGames' => $this->queryBus->handle(new RunningGamesQuery())
+        ]);
+    }
+
+    public function openGamesAction(): Response
+    {
+        return $this->render('@connect-four/open-games.html.twig', [
+            'openGames' => $this->queryBus->handle(new OpenGamesQuery())
         ]);
     }
 }

--- a/src/ConnectFour/Port/Adapter/Http/View/open-games.html.twig
+++ b/src/ConnectFour/Port/Adapter/Http/View/open-games.html.twig
@@ -1,0 +1,4 @@
+<connect-four-game-list open-games="{{ openGames.games|json_encode|e('html_attr') }}"
+                        player-id="{{ app.user ? app.user.userIdentifier|e('html_attr') }}"
+                        maximum-number-of-games="10">
+</connect-four-game-list>

--- a/src/WebInterface/Presentation/Http/PageController.php
+++ b/src/WebInterface/Presentation/Http/PageController.php
@@ -7,7 +7,6 @@ namespace Gaming\WebInterface\Presentation\Http;
 use Gaming\Common\Bus\Bus;
 use Gaming\ConnectFour\Application\Game\Query\GameQuery;
 use Gaming\ConnectFour\Application\Game\Query\GamesByPlayerQuery;
-use Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery;
 use Gaming\WebInterface\Infrastructure\Security\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,10 +24,7 @@ final class PageController
     public function lobbyAction(): Response
     {
         return new Response(
-            $this->twig->render('@web-interface/lobby.html.twig', [
-                'maximumNumberOfGamesInList' => 10,
-                'openGames' => $this->connectFourQueryBus->handle(new OpenGamesQuery())
-            ])
+            $this->twig->render('@web-interface/lobby.html.twig')
         );
     }
 

--- a/src/WebInterface/Presentation/Http/View/lobby.html.twig
+++ b/src/WebInterface/Presentation/Http/View/lobby.html.twig
@@ -12,10 +12,7 @@
             </div>
         </div>
         <div class="col-lg-6">
-            <connect-four-game-list open-games="{{ openGames.games|json_encode|e('html_attr') }}"
-                                    player-id="{{ app.user ? app.user.userIdentifier|e('html_attr') }}"
-                                    maximum-number-of-games="{{ maximumNumberOfGamesInList }}">
-            </connect-four-game-list>
+            {{ render_ssi(controller('connect-four.fragment-controller::openGamesAction')) }}
         </div>
         <div class="col-lg-3 order-first order-lg-last">
             <div class="card">


### PR DESCRIPTION
The fragment is not cacheable since it requires the user id from the session. This can be changed later by pushing the user id to the component from the client. However, this is more about cohesion than performance.