### PR TITLE
Make whole column interactive

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -235,6 +235,30 @@ notification-list {
     }
 }
 
+.gp-cf-token-loading {
+    display: flex;
+    gap: var(--tblr-spacer-1);
+    margin-bottom: var(--tblr-spacer-3);
+}
+
+.gp-cf-token-loading .gp-cf-token {
+    --token-delay: 0s;
+    scale: .9;
+    animation: gp-cf-token-loading 1s linear var(--token-delay) infinite;
+}
+
+@keyframes gp-cf-token-loading {
+    0%, 100% {
+        scale: .9;
+    }
+    20% {
+        scale: 1;
+    }
+    66% {
+        scale: .9;
+    }
+}
+
 connect-four-players .status-dot {
     --tblr-status-size: .7rem;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -231,6 +231,14 @@ notification-list {
     }
 }
 
+.gp-game__field-hitbox {
+    position: absolute;
+    top: calc(var(--tblr-border-width) * -1);
+    left: calc(var(--tblr-border-width) * -1);
+    width: calc(100% + var(--tblr-border-width) * 2);
+    height: calc(100% + var(--tblr-border-width) * 2 + var(--tblr-spacer-1));
+}
+
 connect-four-players .status-dot {
     --tblr-status-size: .7rem;
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -115,7 +115,7 @@ notification-list {
     z-index: 10000;
 }
 
-.gp-game {
+.gp-cf-game {
     --grid-cols: 7;
     display: grid;
     grid-template-columns: repeat(var(--grid-cols), 1fr);
@@ -126,11 +126,11 @@ notification-list {
     padding: var(--tblr-spacer-2);
 }
 
-.gp-game--disabled {
+.gp-cf-game--disabled {
     pointer-events: none;
 }
 
-.gp-game__field {
+.gp-cf-game__field {
     position: relative;
     width: 100%;
     aspect-ratio: 1;
@@ -140,83 +140,25 @@ notification-list {
     cursor: pointer;
 }
 
-.gp-game__field--pending-red,
-.gp-game__field--red {
-    background-color: var(--tblr-red);
-}
-
-.gp-game__field--pending-yellow,
-.gp-game__field--yellow {
-    background-color: var(--tblr-yellow);
-}
-
-.gp-game__field--preview-red:before,
-.gp-game__field--pending-red:before,
-.gp-game__field--red:before,
-.gp-game__field--preview-red:after,
-.gp-game__field--pending-red:after,
-.gp-game__field--red:after,
-.gp-game__field--preview-yellow:before,
-.gp-game__field--pending-yellow:before,
-.gp-game__field--yellow:before,
-.gp-game__field--preview-yellow:after,
-.gp-game__field--pending-yellow:after,
-.gp-game__field--yellow:after {
+.gp-cf-game__field:after {
     content: "";
     position: absolute;
-    border: 5px solid var(--tblr-red-darken);
-    width: 100%;
-    height: 100%;
-    border-radius: 50%;
-    display: inline-block;
-    box-sizing: border-box;
+    top: calc(var(--tblr-border-width) * -1);
+    left: calc(var(--tblr-border-width) * -1 + var(--tblr-spacer-1) / 2 * -1);
+    width: calc(100% + var(--tblr-border-width) * 2 + var(--tblr-spacer-1));
+    height: calc(100% + var(--tblr-border-width) * 2 + var(--tblr-spacer-1));
 }
 
-.gp-game__field--preview-yellow:before,
-.gp-game__field--pending-yellow:before,
-.gp-game__field--yellow:before,
-.gp-game__field--preview-yellow:after,
-.gp-game__field--pending-yellow:after,
-.gp-game__field--yellow:after {
-    border-color: var(--tblr-yellow-darken);
-}
-
-.gp-game__field--preview-red:after,
-.gp-game__field--pending-red:after,
-.gp-game__field--red:after,
-.gp-game__field--preview-yellow:after,
-.gp-game__field--pending-yellow:after,
-.gp-game__field--yellow:after {
-    border-width: 10px;
-    scale: 50%;
-}
-
-.gp-game__field--pending-red:after,
-.gp-game__field--pending-yellow:after {
-    animation: gp-game__field--pending-border 1s ease 1s infinite;
-}
-
-@keyframes gp-game__field--pending-border {
-    0% {
-        border-bottom-color: transparent;
-        transform: rotate(0deg);
-    }
-    100% {
-        border-bottom-color: transparent;
-        transform: rotate(360deg);
-    }
-}
-
-.gp-game__field--highlight.gp-game__field--current {
+.gp-cf-game__field--highlight.gp-cf-game__field--current {
     box-shadow: 0 0 .5em var(--tblr-light);
 }
 
-.gp-game__field--highlight {
-    animation: gp-game__field--highlight 3s infinite;
+.gp-cf-game__field--highlight {
+    animation: gp-cf-game__field--highlight 3s infinite;
     border-color: var(--tblr-light) !important;
 }
 
-@keyframes gp-game__field--highlight {
+@keyframes gp-cf-game__field--highlight {
     20%, 40%, 60% {
         scale: 1;
     }
@@ -231,12 +173,64 @@ notification-list {
     }
 }
 
-.gp-game__field-hitbox {
+.gp-cf-game__field .gp-cf-token {
     position: absolute;
-    top: calc(var(--tblr-border-width) * -1);
-    left: calc(var(--tblr-border-width) * -1);
-    width: calc(100% + var(--tblr-border-width) * 2);
-    height: calc(100% + var(--tblr-border-width) * 2 + var(--tblr-spacer-1));
+    --border-size: calc(35px / var(--grid-cols));
+}
+
+.gp-cf-token {
+    --border-size: 5px;
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    aspect-ratio: 1;
+    background-color: var(--tblr-red);
+    border-radius: 50%;
+}
+
+.gp-cf-token:before,
+.gp-cf-token:after {
+    content: "";
+    position: absolute;
+    border: var(--border-size) solid var(--tblr-red-darken);
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    display: inline-block;
+    box-sizing: border-box;
+}
+
+.gp-cf-token:after {
+    border-width: calc(var(--border-size) * 2);
+    scale: 50%;
+}
+
+.gp-cf-token--yellow {
+    background-color: var(--tblr-yellow);
+}
+
+.gp-cf-token--yellow:before,
+.gp-cf-token--yellow:after {
+    border-color: var(--tblr-yellow-darken);
+}
+
+.gp-cf-token--preview {
+    background-color: initial;
+}
+
+.gp-cf-token--pending:after {
+    animation: gp-cf-token--pending-after 1s ease 1s infinite;
+}
+
+@keyframes gp-cf-token--pending-after {
+    0% {
+        border-bottom-color: transparent;
+        transform: rotate(0deg);
+    }
+    100% {
+        border-bottom-color: transparent;
+        transform: rotate(360deg);
+    }
 }
 
 connect-four-players .status-dot {
@@ -247,12 +241,12 @@ connect-four-players .status-dot-animated:before {
     animation-delay: 0s;
 }
 
-[data-bs-theme=dark] .gp-game {
+[data-bs-theme=dark] .gp-cf-game {
     background-color: var(--tblr-bg-surface);
     border-color: var(--tblr-blue-darken);
 }
 
-[data-bs-theme=dark] .gp-game__field {
+[data-bs-theme=dark] .gp-cf-game__field {
     border-color: var(--tblr-blue-darken);
 }
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -242,19 +242,19 @@ notification-list {
 }
 
 .gp-cf-token-loading .gp-cf-token {
-    --token-delay: 0s;
+    --token-index: 0;
     scale: .9;
-    animation: gp-cf-token-loading 1s linear var(--token-delay) infinite;
+    animation: gp-cf-token-loading 1.4s linear calc(var(--token-index) * .1s) infinite;
 }
 
 @keyframes gp-cf-token-loading {
     0%, 100% {
         scale: .9;
     }
-    20% {
+    15% {
         scale: 1;
     }
-    66% {
+    30% {
         scale: .9;
     }
 }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -132,6 +132,7 @@ notification-list {
 
 .gp-cf-game__field {
     position: relative;
+    text-align: initial;
     width: 100%;
     aspect-ratio: 1;
     background-color: var(--tblr-body-bg);
@@ -182,6 +183,7 @@ notification-list {
     --border-size: 5px;
     position: relative;
     display: inline-block;
+    text-align: initial;
     width: 100%;
     aspect-ratio: 1;
     background-color: var(--tblr-red);

--- a/assets/js/ConnectFour/Game.js
+++ b/assets/js/ConnectFour/Game.js
@@ -12,6 +12,7 @@ customElements.define('connect-four-game', class extends HTMLElement {
                 <div class="gp-game__field"
                      data-column="${(n % game.width) + 1}"
                      data-row="${Math.floor(n / game.width) + 1}">
+                    <span class="gp-game__field-hitbox"></span>
                 </div>`)}
             </div>
         `);
@@ -155,7 +156,8 @@ customElements.define('connect-four-game', class extends HTMLElement {
 
         this._isMoveInProgress = true;
 
-        const field = this._lastFieldInColumn(event.target.dataset.column);
+        const column = event.target.closest('[data-column]').dataset.column;
+        const field = this._lastFieldInColumn(column);
         if (!field) {
             this._isMoveInProgress = false;
             return;
@@ -191,7 +193,8 @@ customElements.define('connect-four-game', class extends HTMLElement {
         if (this._isMoveInProgress) return;
         this._removeFieldPreview();
 
-        this._lastFieldInColumn(event.target.dataset.column)?.classList.add(this._previewClass());
+        const column = event.target.closest('[data-column]').dataset.column;
+        this._lastFieldInColumn(column)?.classList.add(this._previewClass());
     }
 
     _onFieldMouseout(event) {

--- a/assets/js/ConnectFour/Game.js
+++ b/assets/js/ConnectFour/Game.js
@@ -8,11 +8,10 @@ customElements.define('connect-four-game', class extends HTMLElement {
 
         this.append(this._gameNode = html`
             <div style="${`--grid-cols: ${game.width}`}"
-                 class="gp-game">${[...Array(game.height * game.width).keys()].map(n => html`
-                <div class="gp-game__field"
+                 class="gp-cf-game">${[...Array(game.height * game.width).keys()].map(n => html`
+                <div class="gp-cf-game__field"
                      data-column="${(n % game.width) + 1}"
                      data-row="${Math.floor(n / game.width) + 1}">
-                    <span class="gp-game__field-hitbox"></span>
                 </div>`)}
             </div>
         `);
@@ -23,7 +22,7 @@ customElements.define('connect-four-game', class extends HTMLElement {
         this._followMovesButton = document.querySelector(this.getAttribute('follow-moves-selector'));
         this._game = new GameModel(game);
         this._numberOfCurrentMoveInView = this._game.numberOfMoves();
-        this._fields = this._gameNode.querySelectorAll('.gp-game__field');
+        this._fields = this._gameNode.querySelectorAll('.gp-cf-game__field');
         this._changeCurrentPlayer(game.currentPlayerId);
         this._forceFollowMovesAnimation = false;
         this._isMoveInProgress = false;
@@ -43,19 +42,17 @@ customElements.define('connect-four-game', class extends HTMLElement {
     }
 
     /**
-     * @param {Number} color
-     * @param {Boolean} isPending
+     * @param {1|2} color
+     * @param {Boolean} pending
+     * @param {Boolean} preview
+     * @returns {HTMLElement}
      */
-    _colorClass(color, isPending) {
-        const prefix = isPending ? 'gp-game__field--pending-' : 'gp-game__field--';
+    _createTokenNode(color, pending = false, preview = false) {
+        const colorClass = color === 2 ? ' gp-cf-token--yellow' : '';
+        const pendingClass = pending ? ' gp-cf-token--pending' : '';
+        const previewClass = preview ? ' gp-cf-token--preview' : '';
 
-        return color === 1 ? `${prefix}red` : `${prefix}yellow`;
-    }
-
-    _previewClass() {
-        if (this._game.redPlayerId === this._playerId) return 'gp-game__field--preview-red';
-        if (this._game.yellowPlayerId === this._playerId) return 'gp-game__field--preview-yellow';
-        return null;
+        return html`<span class="${`gp-cf-token${colorClass}${pendingClass}${previewClass}`}"></span>`;
     }
 
     /**
@@ -66,7 +63,7 @@ customElements.define('connect-four-game', class extends HTMLElement {
         this._toggleInteractivity();
     }
 
-    _removePendingMove() {
+    _removePendingToken() {
         this._game.pendingMove = null;
         this._showMovesUpTo(this._numberOfCurrentMoveInView);
     }
@@ -75,22 +72,22 @@ customElements.define('connect-four-game', class extends HTMLElement {
         const isCurrentPlayer = this._game.currentPlayerId === this._playerId;
         const isInHistoryMode = this._numberOfCurrentMoveInView !== this._game.numberOfMoves();
 
-        this._gameNode.classList.toggle('gp-game--disabled', !isCurrentPlayer || isInHistoryMode);
+        this._gameNode.classList.toggle('gp-cf-game--disabled', !isCurrentPlayer || isInHistoryMode);
     }
 
     /**
      * @param {Number} index
      */
     _showMovesUpTo(index) {
-        this._fields.forEach(field => field.classList.remove(
-            'gp-game__field--highlight', 'gp-game__field--current', 'gp-game__field--red', 'gp-game__field--yellow',
-            'gp-game__field--pending-red', 'gp-game__field--pending-yellow')
-        );
+        this._fields.forEach(field => {
+            field.innerHTML = '';
+            field.classList.remove('gp-cf-game__field--highlight', 'gp-cf-game__field--current')
+        });
 
         this._game.moves.slice(0, index).forEach((move, i) => {
             const field = this._fieldByPoint(move);
-            field.classList.add(this._colorClass(move.color, this._game.hasPendingMove(move)));
-            if (i === index - 1) field.classList.add('gp-game__field--highlight', 'gp-game__field--current');
+            field.append(this._createTokenNode(move.color, this._game.hasPendingMove(move)));
+            if (i === index - 1) field.classList.add('gp-cf-game__field--highlight', 'gp-cf-game__field--current');
         });
 
         this._updateNavigationButtons();
@@ -98,10 +95,6 @@ customElements.define('connect-four-game', class extends HTMLElement {
         this._toggleInteractivity();
     }
 
-    /**
-     * Updates the previous move, next move und follow moves button according to the state of
-     * the number of the current move in view.
-     */
     _updateNavigationButtons() {
         let isCurrentMoveTheLastMove = this._numberOfCurrentMoveInView === this._game.numberOfMoves();
         this._forceFollowMovesAnimation = isCurrentMoveTheLastMove ? false : this._forceFollowMovesAnimation;
@@ -119,10 +112,10 @@ customElements.define('connect-four-game', class extends HTMLElement {
         if (this._game.winningSequences.length === 0) return;
         if (this._numberOfCurrentMoveInView !== this._game.numberOfMoves()) return;
 
-        this._fields.forEach(field => field.classList.remove('gp-game__field--highlight'));
+        this._fields.forEach(field => field.classList.remove('gp-cf-game__field--highlight'));
         this._game.winningSequences.forEach(winningSequence => {
             winningSequence.points.forEach((point, i) => setTimeout(
-                () => this._fieldByPoint(point).classList.add('gp-game__field--highlight'),
+                () => this._fieldByPoint(point).classList.add('gp-cf-game__field--highlight'),
                 i * 100
             ));
         });
@@ -133,7 +126,7 @@ customElements.define('connect-four-game', class extends HTMLElement {
      * @returns {HTMLElement|undefined}
      */
     _fieldByPoint(point) {
-        return this._gameNode.querySelector(`.gp-game__field[data-column="${point.x}"][data-row="${point.y}"]`);
+        return this._gameNode.querySelector(`.gp-cf-game__field[data-column="${point.x}"][data-row="${point.y}"]`);
     }
 
     /**
@@ -141,14 +134,13 @@ customElements.define('connect-four-game', class extends HTMLElement {
      * @returns {HTMLElement|undefined}
      */
     _lastFieldInColumn(column) {
-        const fields = this._gameNode.querySelectorAll(
-            `.gp-game__field[data-column="${column}"]:not(.gp-game__field--red):not(.gp-game__field--yellow)`
-        );
-        return fields[fields.length - 1];
+        return Array.from(this._gameNode.querySelectorAll(
+            `.gp-cf-game__field[data-column="${column}"]`
+        )).findLast(field => field.querySelector('.gp-cf-token:not(.gp-cf-token--preview)') === null);
     }
 
-    _removeFieldPreview() {
-        this._gameNode.querySelector(`.${this._previewClass()}`)?.classList.remove(this._previewClass());
+    _removePreviewToken() {
+        this._gameNode.querySelector('.gp-cf-token--preview')?.remove();
     }
 
     _onFieldClick(event) {
@@ -156,8 +148,7 @@ customElements.define('connect-four-game', class extends HTMLElement {
 
         this._isMoveInProgress = true;
 
-        const column = event.target.closest('[data-column]').dataset.column;
-        const field = this._lastFieldInColumn(column);
+        const field = this._lastFieldInColumn(event.target.closest('[data-column]').dataset.column);
         if (!field) {
             this._isMoveInProgress = false;
             return;
@@ -177,10 +168,10 @@ customElements.define('connect-four-game', class extends HTMLElement {
             }
         };
         this.dispatchEvent(new CustomEvent('ConnectFour.PlayerMoved', eventOptions));
-        this._removeFieldPreview();
+        this._removePreviewToken();
 
         service.move(this._game.gameId, field.dataset.column)
-            .then(() => this._game.hasPendingMove(eventOptions.detail) && this._removePendingMove())
+            .then(() => this._game.hasPendingMove(eventOptions.detail) && this._removePendingToken())
             .catch(() => {
                 if (!this._game.hasPendingMove(eventOptions.detail)) return;
 
@@ -189,17 +180,18 @@ customElements.define('connect-four-game', class extends HTMLElement {
             .finally(() => this._isMoveInProgress = false);
     }
 
-    _onFieldMouseover(event) {
+    _onFieldMouseenter(event) {
         if (this._isMoveInProgress) return;
-        this._removeFieldPreview();
+        this._removePreviewToken();
 
-        const column = event.target.closest('[data-column]').dataset.column;
-        this._lastFieldInColumn(column)?.classList.add(this._previewClass());
+        this._lastFieldInColumn(event.target.dataset.column)?.append(
+            this._createTokenNode(this._playerId === this._game.redPlayerId ? 1 : 2, false, true)
+        );
     }
 
-    _onFieldMouseout(event) {
+    _onFieldMouseleave() {
         if (this._isMoveInProgress) return;
-        this._removeFieldPreview();
+        this._removePreviewToken();
     }
 
     _onPlayerJoined = event => {
@@ -209,14 +201,14 @@ customElements.define('connect-four-game', class extends HTMLElement {
     }
 
     _onPlayerMoved = event => {
-        if (this._game.hasPendingMove(event.detail)) this._removePendingMove();
+        this._changeCurrentPlayer(event.detail.nextPlayerId);
+        if (this._game.hasPendingMove(event.detail)) this._removePendingToken();
         if (this._game.hasMove(event.detail)) return;
 
         if (!event.detail.pending) this._isMoveInProgress = false;
         if (this._followMovesButton.disabled === true) this._numberOfCurrentMoveInView++;
 
         this._game.appendMove(event.detail);
-        this._changeCurrentPlayer(event.detail.nextPlayerId);
         this._showMovesUpTo(this._numberOfCurrentMoveInView);
     }
 
@@ -272,8 +264,8 @@ customElements.define('connect-four-game', class extends HTMLElement {
 
         this._fields.forEach(field => {
             field.addEventListener('click', this._onFieldClick.bind(this));
-            field.addEventListener('mouseover', this._onFieldMouseover.bind(this));
-            field.addEventListener('mouseout', this._onFieldMouseout.bind(this));
+            field.addEventListener('mouseenter', this._onFieldMouseenter.bind(this));
+            field.addEventListener('mouseleave', this._onFieldMouseleave.bind(this));
         });
 
         this._previousMoveButton.addEventListener('click', this._onPreviousMoveClick.bind(this));

--- a/src/ConnectFour/Port/Adapter/Http/View/challenge.html.twig
+++ b/src/ConnectFour/Port/Adapter/Http/View/challenge.html.twig
@@ -13,7 +13,7 @@
                 <div class="container-tight">
                     <h1>
                         {% if app.user ? app.user.userIdentifier == game.openedBy %}
-                            Waiting for opponent<span class="animated-dots"></span>
+                            Waiting for opponent
                         {% else %}
                             Join the game
                         {% endif %}
@@ -31,6 +31,13 @@
                         Color:
                         <strong>{{ game.preferredStone|replace({1: 'Red', 2: 'Yellow'})|default('Random') }}</strong>
                     </p>
+                    <div class="gp-cf-token-loading w-75 mx-auto">
+                        {% for i in 0..6 %}
+                            <span class="gp-cf-token{{ i is odd ? ' gp-cf-token--yellow' }}"
+                                  style="--token-delay: {{ i / 12 }}s; --border-size: 3px">
+                            </span>
+                        {% endfor %}
+                    </div>
                     {% if app.user ? app.user.userIdentifier == game.openedBy %}
                         <form action="{{ path('connect_four_abort_challenge', {id: game.gameId}) }}"
                               method="post"

--- a/src/ConnectFour/Port/Adapter/Http/View/challenge.html.twig
+++ b/src/ConnectFour/Port/Adapter/Http/View/challenge.html.twig
@@ -31,14 +31,14 @@
                         Color:
                         <strong>{{ game.preferredStone|replace({1: 'Red', 2: 'Yellow'})|default('Random') }}</strong>
                     </p>
-                    <div class="gp-cf-token-loading w-75 mx-auto">
-                        {% for i in 0..6 %}
-                            <span class="gp-cf-token{{ i is odd ? ' gp-cf-token--yellow' }}"
-                                  style="--token-delay: {{ i / 12 }}s; --border-size: 3px">
-                            </span>
-                        {% endfor %}
-                    </div>
                     {% if app.user ? app.user.userIdentifier == game.openedBy %}
+                        <div class="gp-cf-token-loading w-75 mx-auto">
+                            {% for i in 0..6 %}
+                                <span class="gp-cf-token{{ i is odd ? ' gp-cf-token--yellow' }}"
+                                      style="--token-index: {{ i }}; --border-size: 3px">
+                                </span>
+                            {% endfor %}
+                        </div>
                         <form action="{{ path('connect_four_abort_challenge', {id: game.gameId}) }}"
                               method="post"
                               data-abort-form>


### PR DESCRIPTION
This work is part of #13.

This adds a new element for the tokens so the pseudo-element on the field can be used to expand the click area. Another benefit is, that the token can now be used as a standalone element. When the token is part of a game field, the border width is calculated based on the number of columns. Tokens can be used as a loading bar within a `.gp-cf-token-loading` element.

Additionally, prefix CSS classes with `gp-cf-` (the `cf` is new) to avoid conflicts with future games.