### PR TITLE
Filter games on the profile page

### DIFF
--- a/config/connect-four/services/query_bus.yml
+++ b/config/connect-four/services/query_bus.yml
@@ -22,3 +22,7 @@ services:
     Gaming\ConnectFour\Application\Game\Query\RunningGamesHandler:
         arguments: ['@connect-four.running-games-store']
         tags: [{ name: 'gaming_platform_bus.handler', bus: 'connect_four_query' }]
+
+    Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics\PlayerSearchStatisticsHandler:
+        arguments: ['@connect-four.games-by-player-store']
+        tags: [{ name: 'gaming_platform_bus.handler', bus: 'connect_four_query' }]

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,4 @@ parameters:
     - message: "#^Property Gaming\\\\Identity\\\\Domain\\\\Model\\\\User\\\\User\\:\\:\\$version#"
     - message: "#^Property Gaming\\\\Memory\\\\Domain\\\\Model\\\\Game\\\\Game\\:\\:\\$cards is never read, only written\\.$#"
     - message: '#^Cannot access offset [0-9]+ .*Predis.*Pipeline\.$#'
+    - message: '#expects array.*Predis.*Pipeline given\.$#'

--- a/src/ConnectFour/Application/Game/Query/GamesByPlayerHandler.php
+++ b/src/ConnectFour/Application/Game/Query/GamesByPlayerHandler.php
@@ -18,8 +18,11 @@ final class GamesByPlayerHandler
 
     public function __invoke(GamesByPlayerQuery $query): GamesByPlayer
     {
-        return $this->gamesByPlayerFinder->all(
-            $query->playerId()
+        return $this->gamesByPlayerFinder->search(
+            $query->playerId,
+            $query->state,
+            $query->page,
+            $query->limit
         );
     }
 }

--- a/src/ConnectFour/Application/Game/Query/GamesByPlayerQuery.php
+++ b/src/ConnectFour/Application/Game/Query/GamesByPlayerQuery.php
@@ -6,6 +6,7 @@ namespace Gaming\ConnectFour\Application\Game\Query;
 
 use Gaming\Common\Bus\Request;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\State;
 
 /**
  * @implements Request<GamesByPlayer>
@@ -13,12 +14,10 @@ use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
 final class GamesByPlayerQuery implements Request
 {
     public function __construct(
-        private readonly string $playerId
+        public readonly string $playerId,
+        public readonly State $state,
+        public readonly int $page,
+        public readonly int $limit
     ) {
-    }
-
-    public function playerId(): string
-    {
-        return $this->playerId;
     }
 }

--- a/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayer.php
+++ b/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayer.php
@@ -9,11 +9,9 @@ use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
 final class GamesByPlayer
 {
     /**
-     * @param array<string, int> $totals
      * @param Game[] $games
      */
     public function __construct(
-        public readonly array $totals,
         public readonly int $total,
         public readonly array $games
     ) {

--- a/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayer.php
+++ b/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayer.php
@@ -9,10 +9,12 @@ use Gaming\ConnectFour\Application\Game\Query\Model\Game\Game;
 final class GamesByPlayer
 {
     /**
+     * @param array<string, int> $totals
      * @param Game[] $games
      */
     public function __construct(
-        public readonly int $count,
+        public readonly array $totals,
+        public readonly int $total,
         public readonly array $games
     ) {
     }

--- a/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayerStore.php
+++ b/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayerStore.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer;
 
+use Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics\PlayerSearchStatisticsResponse;
+
 interface GamesByPlayerStore
 {
     public function addRunning(string $gameId, string $playerOne, string $playerTwo): void;
@@ -13,6 +15,8 @@ interface GamesByPlayerStore
     public function addWin(string $gameId, string $winnerId, string $loserId): void;
 
     public function addAbort(string $gameId, string $playerOne, string $playerTwo): void;
+
+    public function searchStatistics(string $playerId): PlayerSearchStatisticsResponse;
 
     public function search(string $playerId, State $state, int $page, int $limit): GamesByPlayer;
 }

--- a/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayerStore.php
+++ b/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/GamesByPlayerStore.php
@@ -6,15 +6,13 @@ namespace Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer;
 
 interface GamesByPlayerStore
 {
-    /**
-     * This operation is idempotent.
-     */
-    public function addToPlayer(string $playerId, string $gameId): void;
+    public function addRunning(string $gameId, string $playerOne, string $playerTwo): void;
 
-    /**
-     * This operation is idempotent.
-     */
-    public function removeFromPlayer(string $playerId, string $gameId): void;
+    public function addDraw(string $gameId, string $playerOne, string $playerTwo): void;
 
-    public function all(string $playerId): GamesByPlayer;
+    public function addWin(string $gameId, string $winnerId, string $loserId): void;
+
+    public function addAbort(string $gameId, string $playerOne, string $playerTwo): void;
+
+    public function search(string $playerId, State $state, int $page, int $limit): GamesByPlayer;
 }

--- a/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/State.php
+++ b/src/ConnectFour/Application/Game/Query/Model/GamesByPlayer/State.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer;
+
+enum State: string
+{
+    case ALL = 'all';
+    case RUNNING = 'running';
+    case WON = 'won';
+    case LOST = 'lost';
+    case DRAWN = 'drawn';
+}

--- a/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsHandler.php
+++ b/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics;
+
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayerStore;
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\State;
+
+final class PlayerSearchStatisticsHandler
+{
+    public function __construct(
+        private readonly GamesByPlayerStore $gamesByPlayerStore
+    ) {
+    }
+
+    public function __invoke(PlayerSearchStatisticsQuery $query): PlayerSearchStatisticsResponse
+    {
+        return $query->playerId === null
+            ? new PlayerSearchStatisticsResponse(
+                array_combine(
+                    array_map(static fn(State $state): string => $state->value, State::cases()),
+                    array_fill(0, count(State::cases()), 0)
+                )
+            )
+            : $this->gamesByPlayerStore->searchStatistics($query->playerId);
+    }
+}

--- a/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsQuery.php
+++ b/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsQuery.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics;
+
+use Gaming\Common\Bus\Request;
+
+/**
+ * @implements Request<PlayerSearchStatisticsResponse>
+ */
+final class PlayerSearchStatisticsQuery implements Request
+{
+    public function __construct(
+        public readonly ?string $playerId
+    ) {
+    }
+}

--- a/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsResponse.php
+++ b/src/ConnectFour/Application/Game/Query/PlayerSearchStatistics/PlayerSearchStatisticsResponse.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics;
+
+final class PlayerSearchStatisticsResponse
+{
+    /**
+     * @param array<string, int> $states
+     */
+    public function __construct(
+        public readonly array $states
+    ) {
+    }
+}

--- a/src/ConnectFour/Port/Adapter/Http/FragmentController.php
+++ b/src/ConnectFour/Port/Adapter/Http/FragmentController.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Gaming\ConnectFour\Port\Adapter\Http;
 
 use Gaming\Common\Bus\Bus;
+use Gaming\ConnectFour\Application\Game\Query\PlayerSearchStatistics\PlayerSearchStatisticsQuery;
 use Gaming\ConnectFour\Application\Game\Query\OpenGamesQuery;
 use Gaming\ConnectFour\Application\Game\Query\RunningGamesQuery;
 use Gaming\ConnectFour\Port\Adapter\Http\Form\OpenType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\Cache;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 final class FragmentController extends AbstractController
 {
@@ -39,6 +42,15 @@ final class FragmentController extends AbstractController
     {
         return $this->render('@connect-four/open.html.twig', [
             'form' => $this->createForm(OpenType::class)
+        ]);
+    }
+
+    public function playerSearchFilterAction(#[CurrentUser] ?UserInterface $user): Response
+    {
+        return $this->render('@connect-four/player-search-filter.html.twig', [
+            'playerSearchStatistics' => $this->queryBus->handle(
+                new PlayerSearchStatisticsQuery($user?->getUserIdentifier())
+            )
         ]);
     }
 }

--- a/src/ConnectFour/Port/Adapter/Http/View/player-search-filter.html.twig
+++ b/src/ConnectFour/Port/Adapter/Http/View/player-search-filter.html.twig
@@ -1,0 +1,16 @@
+<input type="checkbox" id="filters-toggle" class="gp-expand-toggle">
+<label for="filters-toggle" class="d-md-none w-100 btn dropdown-toggle">
+    Apply filters
+</label>
+<div class="d-md-block sticky-md-top">
+    <div class="subheader mb-2">State</div>
+    <div class="list-group mb-3">
+        {% for state, total in playerSearchStatistics.states %}
+            <a href="{{ path('profile', state == 'all' ? {} :{state: state}) }}"
+               class="list-group-item list-group-item-action d-flex align-items-center{{ app.request.query.get('state', 'all') == state ? ' active' }}">
+                {{ state|capitalize }}
+                <small class="text-secondary ms-auto">{{ total }}</small>
+            </a>
+        {% endfor %}
+    </div>
+</div>

--- a/src/ConnectFour/Port/Adapter/Persistence/Projection/GamesByPlayerProjection.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Projection/GamesByPlayerProjection.php
@@ -9,6 +9,9 @@ use Gaming\Common\EventStore\NoCommit;
 use Gaming\Common\EventStore\StoredEventSubscriber;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayerStore;
 use Gaming\ConnectFour\Domain\Game\Event\GameAborted;
+use Gaming\ConnectFour\Domain\Game\Event\GameDrawn;
+use Gaming\ConnectFour\Domain\Game\Event\GameResigned;
+use Gaming\ConnectFour\Domain\Game\Event\GameWon;
 use Gaming\ConnectFour\Domain\Game\Event\PlayerJoined;
 
 final class GamesByPlayerProjection implements StoredEventSubscriber
@@ -26,6 +29,9 @@ final class GamesByPlayerProjection implements StoredEventSubscriber
 
         match ($content::class) {
             PlayerJoined::class => $this->handlePlayerJoined($content),
+            GameDrawn::class => $this->handleGameDrawn($content),
+            GameWon::class => $this->handleGameWon($content),
+            GameResigned::class => $this->handleGameResigned($content),
             GameAborted::class => $this->handleGameAborted($content),
             default => true
         };
@@ -33,14 +39,37 @@ final class GamesByPlayerProjection implements StoredEventSubscriber
 
     private function handlePlayerJoined(PlayerJoined $playerJoined): void
     {
-        $this->gamesByPlayerStore->addToPlayer(
-            $playerJoined->joinedPlayerId(),
-            $playerJoined->aggregateId()
+        $this->gamesByPlayerStore->addRunning(
+            $playerJoined->aggregateId(),
+            $playerJoined->redPlayerId,
+            $playerJoined->yellowPlayerId
         );
+    }
 
-        $this->gamesByPlayerStore->addToPlayer(
-            $playerJoined->opponentPlayerId(),
-            $playerJoined->aggregateId()
+    private function handleGameDrawn(GameDrawn $gameDrawn): void
+    {
+        $this->gamesByPlayerStore->addDraw(
+            $gameDrawn->aggregateId(),
+            $gameDrawn->playerIds[0] ?? '',
+            $gameDrawn->playerIds[1] ?? ''
+        );
+    }
+
+    private function handleGameWon(GameWon $gameWon): void
+    {
+        $this->gamesByPlayerStore->addWin(
+            $gameWon->aggregateId(),
+            $gameWon->winnerId,
+            $gameWon->loserId
+        );
+    }
+
+    private function handleGameResigned(GameResigned $gameResigned): void
+    {
+        $this->gamesByPlayerStore->addWin(
+            $gameResigned->aggregateId(),
+            $gameResigned->opponentPlayerId(),
+            $gameResigned->resignedPlayerId()
         );
     }
 
@@ -51,14 +80,10 @@ final class GamesByPlayerProjection implements StoredEventSubscriber
             return;
         }
 
-        $this->gamesByPlayerStore->removeFromPlayer(
+        $this->gamesByPlayerStore->addAbort(
+            $gameAborted->aggregateId(),
             $gameAborted->abortedPlayerId(),
-            $gameAborted->aggregateId()
-        );
-
-        $this->gamesByPlayerStore->removeFromPlayer(
-            $gameAborted->opponentPlayerId(),
-            $gameAborted->aggregateId()
+            $gameAborted->opponentPlayerId()
         );
     }
 }

--- a/src/ConnectFour/Port/Adapter/Persistence/Repository/PredisGameStore.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Repository/PredisGameStore.php
@@ -42,10 +42,13 @@ final class PredisGameStore implements GameStore
         }
 
         return array_map(
-            fn(string $storedGame): Game => $this->deserializeGame($storedGame),
+            fn(?string $storedGame, GameId $gameId): Game => $storedGame !== null
+                ? $this->deserializeGame($storedGame)
+                : $this->fallbackGameFinder->find($gameId),
             $this->predis->mget(
                 array_map(fn(GameId $gameId): string => $this->storageKeyPrefix . $gameId, $gameIds)
-            )
+            ),
+            $gameIds
         );
     }
 

--- a/src/ConnectFour/Port/Adapter/Persistence/Repository/PredisGamesByPlayerStore.php
+++ b/src/ConnectFour/Port/Adapter/Persistence/Repository/PredisGamesByPlayerStore.php
@@ -7,6 +7,7 @@ namespace Gaming\ConnectFour\Port\Adapter\Persistence\Repository;
 use Gaming\ConnectFour\Application\Game\Query\Model\Game\GameFinder;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayerStore;
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\State;
 use Gaming\ConnectFour\Domain\Game\GameId;
 use Predis\Client;
 use Predis\ClientContextInterface;
@@ -20,41 +21,84 @@ final class PredisGamesByPlayerStore implements GamesByPlayerStore
     ) {
     }
 
-    public function addToPlayer(string $playerId, string $gameId): void
+    public function addRunning(string $gameId, string $playerOne, string $playerTwo): void
     {
-        $this->predis->zadd(
-            $this->storageKeyForPlayer($playerId),
-            [$gameId => microtime(true)]
+        $this->predis->pipeline(
+            function (ClientContextInterface $pipeline) use ($gameId, $playerOne, $playerTwo): void {
+                $pipeline->zadd($this->keyForPlayer($playerOne, State::ALL->value), [$gameId => microtime(true)]);
+                $pipeline->zadd($this->keyForPlayer($playerOne, State::RUNNING->value), [$gameId => microtime(true)]);
+                $pipeline->zadd($this->keyForPlayer($playerTwo, State::ALL->value), [$gameId => microtime(true)]);
+                $pipeline->zadd($this->keyForPlayer($playerTwo, State::RUNNING->value), [$gameId => microtime(true)]);
+            }
         );
     }
 
-    public function removeFromPlayer(string $playerId, string $gameId): void
+    public function addDraw(string $gameId, string $playerOne, string $playerTwo): void
     {
-        $this->predis->zrem(
-            $this->storageKeyForPlayer($playerId),
-            $gameId
+        $this->predis->pipeline(
+            function (ClientContextInterface $pipeline) use ($gameId, $playerOne, $playerTwo): void {
+                $pipeline->zrem($this->keyForPlayer($playerOne, State::RUNNING->value), $gameId);
+                $pipeline->zadd($this->keyForPlayer($playerOne, State::DRAWN->value), [$gameId => microtime(true)]);
+                $pipeline->zrem($this->keyForPlayer($playerTwo, State::RUNNING->value), $gameId);
+                $pipeline->zadd($this->keyForPlayer($playerTwo, State::DRAWN->value), [$gameId => microtime(true)]);
+            }
         );
     }
 
-    public function all(string $playerId): GamesByPlayer
+    public function addWin(string $gameId, string $winnerId, string $loserId): void
     {
+        $this->predis->pipeline(
+            function (ClientContextInterface $pipeline) use ($gameId, $winnerId, $loserId): void {
+                $pipeline->zrem($this->keyForPlayer($winnerId, State::RUNNING->value), $gameId);
+                $pipeline->zadd($this->keyForPlayer($winnerId, State::WON->value), [$gameId => microtime(true)]);
+                $pipeline->zrem($this->keyForPlayer($loserId, State::RUNNING->value), $gameId);
+                $pipeline->zadd($this->keyForPlayer($loserId, State::LOST->value), [$gameId => microtime(true)]);
+            }
+        );
+    }
+
+    public function addAbort(string $gameId, string $playerOne, string $playerTwo): void
+    {
+        $this->predis->pipeline(
+            function (ClientContextInterface $pipeline) use ($gameId, $playerOne, $playerTwo): void {
+                $pipeline->zrem($this->keyForPlayer($playerOne, State::ALL->value), $gameId);
+                $pipeline->zrem($this->keyForPlayer($playerOne, State::RUNNING->value), $gameId);
+                $pipeline->zrem($this->keyForPlayer($playerTwo, State::ALL->value), $gameId);
+                $pipeline->zrem($this->keyForPlayer($playerTwo, State::RUNNING->value), $gameId);
+            }
+        );
+    }
+
+    public function search(string $playerId, State $state, int $page, int $limit): GamesByPlayer
+    {
+        $offset = max(0, $page - 1) * $limit;
+        $states = array_map(static fn(State $s): string => $s->value, State::cases());
+
         $responses = $this->predis->pipeline(
-            function (ClientContextInterface $pipeline) use ($playerId): void {
-                $pipeline->zcount($this->storageKeyForPlayer($playerId), '-inf', '+inf');
-                $pipeline->zrevrange($this->storageKeyForPlayer($playerId), 0, 100);
+            function (ClientContextInterface $pipeline) use ($playerId, $states, $state, $offset, $limit): void {
+                $pipeline->zrevrange(
+                    $this->keyForPlayer($playerId, $state->value),
+                    $offset,
+                    $offset + $limit - 1
+                );
+
+                foreach ($states as $state) {
+                    $pipeline->zcard($this->keyForPlayer($playerId, $state));
+                }
             }
         );
 
         return new GamesByPlayer(
-            (int)$responses[0],
+            $totals = array_combine($states, array_slice($responses, 1)),
+            $totals[$state->value],
             $this->gameFinder->findMany(
-                array_map(static fn(string $gameId): GameId => GameId::fromString($gameId), $responses[1])
+                array_map(static fn(string $gameId): GameId => GameId::fromString($gameId), $responses[0])
             )
         );
     }
 
-    private function storageKeyForPlayer(string $playerId): string
+    private function keyForPlayer(string $playerId, string $state): string
     {
-        return $this->storageKeyPrefix . $playerId;
+        return $this->storageKeyPrefix . $playerId . ':' . $state;
     }
 }

--- a/src/WebInterface/Presentation/Http/PageController.php
+++ b/src/WebInterface/Presentation/Http/PageController.php
@@ -45,7 +45,7 @@ final class PageController
             $this->twig->render('@web-interface/profile.html.twig', [
                 'gamesPerPage' => $gamesPerPage = 12,
                 'gamesByPlayer' => $user === null
-                    ? new GamesByPlayer(['all' => 0], 0, [])
+                    ? new GamesByPlayer(0, [])
                     : $this->connectFourQueryBus->handle(
                         new GamesByPlayerQuery(
                             $user->getUserIdentifier(),

--- a/src/WebInterface/Presentation/Http/PageController.php
+++ b/src/WebInterface/Presentation/Http/PageController.php
@@ -8,6 +8,7 @@ use Gaming\Common\Bus\Bus;
 use Gaming\ConnectFour\Application\Game\Query\GameQuery;
 use Gaming\ConnectFour\Application\Game\Query\GamesByPlayerQuery;
 use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\GamesByPlayer;
+use Gaming\ConnectFour\Application\Game\Query\Model\GamesByPlayer\State;
 use Gaming\WebInterface\Infrastructure\Security\User;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -42,9 +43,17 @@ final class PageController
     {
         return new Response(
             $this->twig->render('@web-interface/profile.html.twig', [
-                'gamesByPlayer' => $user !== null
-                    ? $this->connectFourQueryBus->handle(new GamesByPlayerQuery($user->getUserIdentifier()))
-                    : new GamesByPlayer(0, [])
+                'gamesPerPage' => $gamesPerPage = 12,
+                'gamesByPlayer' => $user === null
+                    ? new GamesByPlayer(['all' => 0], 0, [])
+                    : $this->connectFourQueryBus->handle(
+                        new GamesByPlayerQuery(
+                            $user->getUserIdentifier(),
+                            State::tryFrom($request->query->getString('state', State::ALL->value)) ?? State::ALL,
+                            $request->query->getInt('page', 1),
+                            $gamesPerPage
+                        )
+                    )
             ])
         );
     }

--- a/src/WebInterface/Presentation/Http/View/profile.html.twig
+++ b/src/WebInterface/Presentation/Http/View/profile.html.twig
@@ -21,13 +21,20 @@
             <div class="d-md-block sticky-md-top">
                 <div class="subheader mb-2">State</div>
                 <div class="list-group mb-3">
-                    <a href="{{ path('profile') }}"
-                       class="list-group-item list-group-item-action d-flex align-items-center active">
-                        All
-                        <small class="text-secondary ms-auto">{{ gamesByPlayer.count }}</small>
-                    </a>
+                    {% for state, total in gamesByPlayer.totals %}
+                        <a href="{{ path('profile', state == 'all' ? {} :{state: state}) }}"
+                           class="list-group-item list-group-item-action d-flex align-items-center{{ app.request.query.get('state', 'all') == state ? ' active' }}">
+                            {{ state|capitalize }}
+                            <small class="text-secondary ms-auto">{{ total }}</small>
+                        </a>
+                    {% endfor %}
                 </div>
             </div>
+            <p class="d-md-none small text-secondary mb-1">
+                State: {{ app.request.query.get('state', 'all')|capitalize }}
+                •
+                Page: {{ max(1, app.request.query.getInt('page', 1)) }}
+            </p>
         </div>
         <div class="col-md-8 col-lg-9 gp-cf-game-list">
             <div class="row row-deck row-gap-2">
@@ -87,6 +94,17 @@
                         </div>
                     </div>
                 {% endfor %}
+                {% if gamesByPlayer.total > 0 %}
+                    <div class="col-12">
+                        {% include 'include/pagination.html.twig' with {
+                            'page': app.request.query.getInt('page', 1),
+                            'total': gamesByPlayer.total,
+                            'limit': gamesPerPage,
+                            'previousTitle': 'Games',
+                            'nextTitle': 'Games'
+                        } %}
+                    </div>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/src/WebInterface/Presentation/Http/View/profile.html.twig
+++ b/src/WebInterface/Presentation/Http/View/profile.html.twig
@@ -14,30 +14,15 @@
     </div>
     <div class="row">
         <div class="col-md-4 col-lg-3">
-            <input type="checkbox" id="filters-toggle" class="gp-expand-toggle">
-            <label for="filters-toggle" class="d-md-none w-100 btn dropdown-toggle">
-                Apply filters
-            </label>
-            <div class="d-md-block sticky-md-top">
-                <div class="subheader mb-2">State</div>
-                <div class="list-group mb-3">
-                    {% for state, total in gamesByPlayer.totals %}
-                        <a href="{{ path('profile', state == 'all' ? {} :{state: state}) }}"
-                           class="list-group-item list-group-item-action d-flex align-items-center{{ app.request.query.get('state', 'all') == state ? ' active' }}">
-                            {{ state|capitalize }}
-                            <small class="text-secondary ms-auto">{{ total }}</small>
-                        </a>
-                    {% endfor %}
-                </div>
-            </div>
-            <p class="d-md-none small text-secondary mb-1">
+            {{ render_ssi(controller('connect-four.fragment-controller::playerSearchFilterAction', {}, app.request.query.all)) }}
+        </div>
+        <div class="col-md-8 col-lg-9 gp-cf-game-list">
+            <p class="small text-secondary mb-1">
                 State: {{ app.request.query.get('state', 'all')|capitalize }}
                 •
                 Page: {{ max(1, app.request.query.getInt('page', 1)) }}
             </p>
-        </div>
-        <div class="col-md-8 col-lg-9 gp-cf-game-list">
-            <div class="row row-deck row-gap-2">
+            <div class="row row-deck row-cards">
                 {% for game in gamesByPlayer.games %}
                     <div class="col-sm-6 col-lg-4">
                         <div class="card">

--- a/src/WebInterface/Presentation/Http/View/profile.html.twig
+++ b/src/WebInterface/Presentation/Http/View/profile.html.twig
@@ -14,13 +14,25 @@
     </div>
     <div class="row">
         <div class="col-md-4 col-lg-3">
-            {{ render_ssi(controller('connect-four.fragment-controller::playerSearchFilterAction', {}, app.request.query.all)) }}
+            {{ render_ssi(controller(
+                'connect-four.fragment-controller::playerSearchFilterAction',
+                {},
+                app.request.query.all|filter((v, k) => k == 'state')
+            )) }}
         </div>
         <div class="col-md-8 col-lg-9 gp-cf-game-list">
-            <p class="small text-secondary mb-1">
-                State: {{ app.request.query.get('state', 'all')|capitalize }}
-                •
-                Page: {{ max(1, app.request.query.getInt('page', 1)) }}
+            <p class="small mb-1">
+                <span class="text-secondary">
+                    State: {{ app.request.query.get('state', 'all')|capitalize }}
+                    •
+                    Page: {{ max(1, app.request.query.getInt('page', 1)) }}
+                </span>
+                {% if app.request.query.get('state', 'all') != 'all' or app.request.query.get('page', 1) != 1 %}
+                    <span class="text-secondary">•</span>
+                    <a href="{{ path('profile') }}">
+                        Clear all filters
+                    </a>
+                {% endif %}
             </p>
             <div class="row row-deck row-cards">
                 {% for game in gamesByPlayer.games %}

--- a/templates/include/pagination.html.twig
+++ b/templates/include/pagination.html.twig
@@ -1,0 +1,23 @@
+{% set totalPages = (total / limit)|round(0, 'ceil') %}
+{% set previousPage = max(page - 1, 1) %}
+{% set nextPage = min(page + 1, totalPages) %}
+<div class="card">
+    <div class="card-body">
+        <ul class="pagination">
+            <li class="page-item page-prev{{ page <= 1 ? ' disabled' }}">
+                <a class="page-link"
+                   href="{{ path('profile', app.request.query.all|merge({'page': previousPage})) }}">
+                    <div class="page-item-subtitle">previous</div>
+                    <div class="page-item-title">{{ previousTitle }}</div>
+                </a>
+            </li>
+            <li class="page-item page-next{{ page >= totalPages ? ' disabled' }}">
+                <a class="page-link"
+                   href="{{ path('profile', app.request.query.all|merge({'page': nextPage})) }}">
+                    <div class="page-item-subtitle">next</div>
+                    <div class="page-item-title">{{ nextTitle }}</div>
+                </a>
+            </li>
+        </ul>
+    </div>
+</div>

--- a/templates/include/pagination.html.twig
+++ b/templates/include/pagination.html.twig
@@ -1,6 +1,6 @@
 {% set totalPages = (total / limit)|round(0, 'ceil') %}
-{% set previousPage = max(page - 1, 1) %}
-{% set nextPage = min(page + 1, totalPages) %}
+{% set previousPage = min(max(page - 1, 1), totalPages) %}
+{% set nextPage = max(min(page + 1, totalPages), 2) %}
 <div class="card">
     <div class="card-body">
         <ul class="pagination">


### PR DESCRIPTION
This continues to use Redis for secondary indexing. A `ZSET` is maintained for each player and game state (all, running, won, lost, drawn), scored by insertion time. An `index with 100,000 games` takes around `12 MB` via `MEMORY USAGE`.

Advanced lookups, such as games against a specific player, could be implemented by `ZINTERSTORE` the two most selective sets (e.g. player-1:won and player-2:lost, player-1:drawn player-2:drawn) into a short-lived key, then calling `ZCARD` and `ZREVRANGE`.

Because this is using way more sorted set commands, the performance was tested with the `/deploy/load-test` deployment. 30k req/s over >10 minutes. No hiccups. The StoredEventListener had a parallelism of 1 for each shard. Replaying the whole event stream of a single shard, after having >10 minutes of constant play in the table, took around ~1 1/2 minutes (>10k `ZSET` and 4k `ZREM` executions per second). Although this can be speeded up by grouping more Redis commands within a pipeline, or using another indexing technique, e.g. RediSearch, this is fast enough.