### PR TITLE
Fix preload notice

### DIFF
--- a/src/Common/SymfonyPrometheus/MetricsController.php
+++ b/src/Common/SymfonyPrometheus/MetricsController.php
@@ -27,7 +27,7 @@ final class MetricsController
         return new Response(
             new RenderTextFormat()->render($this->registry->getMetricFamilySamples()),
             200,
-            ['Content-Type' => 'text/plain']
+            ['Content-Type' => RenderTextFormat::MIME_TYPE]
         );
     }
 }


### PR DESCRIPTION
Preloader cannot autoload dependencies of anonymous classes. This fixes the notice by using the `ClosureRequestHandler` instead.

Also, use the correct mime type for metric responses.